### PR TITLE
refactor: rename project from PyREPL3 to Capsule

### DIFF
--- a/.review-criteria.md
+++ b/.review-criteria.md
@@ -1,41 +1,136 @@
-# PyREPL3 Review Criteria
+# Capsule Review Criteria
 
-Project-specific review criteria for the PyREPL3 subprocess-isolated Python execution service.
+Project-specific review criteria for the Capsule subprocess-isolated Python execution service.
+
+> **IMPORTANT**: We are in a transition phase from ThreadedExecutor to AsyncExecutor + Resonate architecture. Both patterns are acceptable during this transition.
 
 <architecture>
 ## Architecture Requirements
+
+### Current State (Acceptable During Transition)
+- ThreadedExecutor for synchronous code execution
+- Direct namespace manipulation
+- Basic message protocol without full field population
+- Future-based correlation patterns
+
+### Target Architecture (Where We're Going)
+- AsyncExecutor with execution mode routing (top-level await, async, blocking I/O, simple sync)
+- Promise-based communication preparing for Resonate SDK integration
+- Capability-based dependency injection
+- Durable namespace management with crash recovery
+
+### Invariants (Must Always Be True)
 - Maintain strict separation between protocol, session, subprocess, and API layers
 - All background operations must use asyncio.Event - no polling loops
-- User code runs in threads, infrastructure must remain async
+- User code runs in appropriate context (thread for blocking, async for await)
 - Single-reader invariant: only one execution per session at a time
 - Event-driven patterns only (except hybrid health check baseline)
 </architecture>
+
+<namespace-management>
+## Namespace Management - CRITICAL
+
+### The Golden Rule
+**NEVER replace the namespace dictionary, ALWAYS merge updates**
+```python
+# ❌ WRONG - Causes KeyError failures
+self._namespace = new_namespace
+
+# ✅ CORRECT - Preserves engine internals
+self._namespace.update(new_namespace)
+```
+
+### Protected Keys
+Engine internals that must be preserved:
+- `_`, `__`, `___` (last results)
+- `_i`, `_ii`, `_iii` (last inputs)
+- `Out`, `In` (history)
+- `_oh`, `_ih` (IPython compatibility)
+- `_exit_code`, `_exception`
+
+### Merge Strategies
+- User code: Cannot overwrite engine internals
+- Engine code: Can modify internals
+- Thread results: Merge with conflict resolution
+</namespace-management>
+
+<execution-modes>
+## Execution Mode Requirements
+
+### Code Analysis Required
+Every execution must analyze code to determine mode:
+1. **TOP_LEVEL_AWAIT**: Contains await at module level → AsyncExecutor with PyCF_ALLOW_TOP_LEVEL_AWAIT (0x1000000)
+2. **ASYNC_DEF**: Contains async function definitions → AsyncExecutor
+3. **BLOCKING_SYNC**: Uses blocking I/O (requests, socket, etc.) → ThreadedExecutor
+4. **SIMPLE_SYNC**: Simple synchronous code → Direct execution or ThreadedExecutor
+
+### Async Executor Requirements
+- Use compile flag `PyCF_ALLOW_TOP_LEVEL_AWAIT = 0x1000000` for top-level await
+- Never use `dont_inherit=True` in compile() - breaks cancellation
+- Handle coroutine lifecycle properly (track, close on cleanup)
+- Use existing event loop - DO NOT create new loops
+</execution-modes>
+
+<event-loop-management>
+## Event Loop Management
+
+### Critical Rules
+1. **Get or set loop BEFORE creating asyncio objects**
+```python
+# ✅ CORRECT
+loop = asyncio.get_running_loop() or asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
+event = asyncio.Event()  # Now uses correct loop
+
+# ❌ WRONG
+event = asyncio.Event()  # Might bind to wrong loop
+loop = asyncio.get_running_loop()  # Too late!
+```
+
+2. **All asyncio objects in a session must use the same loop**
+3. **ThreadedExecutor must coordinate with main loop via `call_soon_threadsafe`**
+</event-loop-management>
 
 <concurrency>
 ## Concurrency & Threading
 - Never hold locks during expensive operations (subprocess creation, I/O)
 - Use placeholder reservation pattern for pool operations
-- Thread-safe async bridge for user code execution
+- Thread-safe async bridge required for ThreadedExecutor
 - Use asyncio.Queue for async producer/consumer patterns
 - call_soon_threadsafe for thread-to-async communication
+- RLock for namespace access (supports reentrant access)
 </concurrency>
 
 <session-management>
 ## Session Management
 - Sessions must track state with proper transitions
+- Initial state after startup should be IDLE or READY (fix inconsistency)
 - Use async with session._state_lock for state changes
 - Always check session.state before operations
 - Handle TERMINATED state gracefully
 - Session reuse is mandatory - each Session() creates new subprocess
+- Event loop must be consistent throughout session lifetime
 </session-management>
 
 <message-protocol>
 ## Message Protocol Requirements
+
+### Required Fields (Must Be Present)
 - All messages inherit from BaseMessage with id and timestamp
+- ResultMessage MUST include `execution_time` field
+- HeartbeatMessage MUST include `memory_usage`, `cpu_percent`, `namespace_size`
+- CheckpointMessage MUST include all data fields when used
+
+### Protocol Rules
 - Use MessageType enum for type field
 - Messages serialized with MessagePack (fallback to JSON)
 - 4-byte length prefix for framing
 - Correlation IDs must be maintained (e.g., InputMessage.id → InputResponseMessage.input_id)
+
+### Future: Promise-Based Correlation
+- Moving toward promise-based patterns (preparation for Resonate)
+- Correlation will use promise IDs instead of manual tracking
+- Support both patterns during transition
 </message-protocol>
 
 <performance>
@@ -45,40 +140,133 @@ Project-specific review criteria for the PyREPL3 subprocess-isolated Python exec
 - Use flush sentinels for output ordering
 - Event-driven patterns reduce CPU usage by >99%
 - Session pool should maintain warm sessions to avoid startup delay
+- Async wrapper overhead acceptable during transition (< 5ms)
+- Target < 5% overhead for local mode Resonate integration
 </performance>
 
 <error-handling>
 ## Error Handling & Cancellation
+
+### Current Cancellation (ThreadedExecutor)
 - Two-tier cancellation: cooperative via sys.settrace, hard via worker restart
 - Never use dont_inherit=True in compile() - breaks cancellation
 - Check cancellation event on each line/call (100 check interval)
 - Always allow for cleanup in cooperative cancellation
+
+### Future Cancellation (AsyncExecutor)
+- Will use asyncio cancellation for async code
+- Resonate will provide durable cancellation tokens
+- Must support both patterns during transition
+
+### Input Handling
 - Input handling must respond with correct correlation ID
+- Future: Will use promise resolution for input responses
 </error-handling>
 
 <testing>
 ## Testing Requirements
+
+### Transition Period Requirements
+- Tests may expect AsyncExecutor interface - provide async wrappers
+- Both ThreadedExecutor and AsyncExecutor patterns acceptable
+- Fix Pydantic validation by providing all required fields
+- Handle event loop binding issues in fixtures
+
+### General Requirements
 - Default to session reuse in tests (new Session() needs justification)
 - Start background tasks explicitly (transport.start(), pool.start())
 - Handle InputMessage in execute loops with proper response
 - Allow for subprocess startup time (minimum 50-100ms)
 - Use fixtures from tests/fixtures/ for consistency
+- Ensure event loop consistency in test setup
 </testing>
+
+<migration-path>
+## Migration Path Considerations
+
+### Phase 1: Foundation Fixes (Current Priority)
+- Add async wrappers to ThreadedExecutor for test compatibility
+- Fix message protocol field completeness
+- Implement namespace merge-only policy
+- Fix event loop management
+
+### Phase 2: Bridge Architecture
+- Create AsyncExecutor skeleton that delegates to ThreadedExecutor
+- Add execution mode routing
+- Implement promise abstraction layer
+- Create capability base classes
+
+### Phase 3: Full Implementation
+- Complete AsyncExecutor with PyCF_ALLOW_TOP_LEVEL_AWAIT
+- Integrate Resonate SDK
+- Implement durable functions
+- Complete capability system
+
+### Review Focus
+During transition, prioritize:
+1. **Correctness**: Namespace preservation, message completeness
+2. **Compatibility**: Support both old and new patterns
+3. **Foundation**: Build toward target architecture
+4. **Documentation**: Mark temporary vs permanent patterns
+</migration-path>
 
 <security>
 ## Security Considerations
 - Never expose or log secrets and keys
 - Validate all inputs before execution
-- Namespace isolation between executions
+- Namespace isolation between executions (merge-only helps here)
 - Transaction support for rollback capability
 - Source tracking for executed code
+- Capability-based security (future) - prepare interfaces
 </security>
 
 <documentation>
 ## Documentation Standards
+
+### Required Documentation
 - Document state transitions clearly
 - Include timing expectations in comments
 - Document lock usage and scope
 - Explain event-driven patterns used
 - Note any deviation from standard async patterns
+
+### Transition Documentation
+- Mark temporary patterns with `# TODO: Temporary until AsyncExecutor`
+- Mark future patterns with `# Future: Will use Resonate promises`
+- Document which execution mode a code path handles
+- Explain namespace merge vs replace decisions
+
+### Code Comments
+- Reference spec line numbers for complex implementations
+- Link to relevant documentation files
+- Explain WHY, not just what (especially for workarounds)
 </documentation>
+
+## Review Priorities
+
+When reviewing PRs, prioritize in this order:
+
+1. **Critical Correctness**
+   - Namespace never replaced (always merged)
+   - Event loop consistency
+   - Message protocol completeness
+
+2. **Architectural Alignment**
+   - Moving toward AsyncExecutor + Resonate
+   - Promise-based patterns over manual correlation
+   - Execution mode routing preparation
+
+3. **Test Stability**
+   - Tests pass or have clear fix path
+   - Event loop issues resolved
+   - Async/sync bridge working
+
+4. **Performance**
+   - Acceptable transition overhead (< 5%)
+   - No polling loops
+   - Event-driven patterns
+
+5. **Future Readiness**
+   - Interfaces support future patterns
+   - Clear migration path
+   - Proper abstraction layers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to PyREPL3 will be documented in this file.
+All notable changes to Capsule will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Initial release of PyREPL3
+- Initial release of Capsule
 - Subprocess-isolated execution service with managed process pools
 - Session-oriented RPC with persistent namespaces
 - Interactive input() support via thread-based execution model
@@ -45,5 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Protocol layer with MessagePack/JSON support
 - ThreadedExecutor for blocking I/O support
 
-[Unreleased]: https://github.com/your-username/pyrepl3/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/your-username/pyrepl3/releases/tag/v0.1.0
+[Unreleased]: https://github.com/your-username/capsule/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/your-username/capsule/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
-# Contributing to PyREPL3
+# Contributing to Capsule
 
-Thank you for your interest in contributing to PyREPL3! This document provides guidelines and instructions for contributing to the project.
+Thank you for your interest in contributing to Capsule! This document provides guidelines and instructions for contributing to the project.
 
 ## Development Setup
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/your-username/pyrepl3.git
-   cd pyrepl3
+   git clone https://github.com/your-username/capsule.git
+   cd capsule
    ```
 
 2. Create a virtual environment:
@@ -127,4 +127,4 @@ ruff check src/ tests/
 
 ## License
 
-By contributing to PyREPL3, you agree that your contributions will be licensed under the MIT License.
+By contributing to Capsule, you agree that your contributions will be licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 PyREPL3 Contributors
+Copyright (c) 2024 Capsule Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,408 +1,273 @@
-# PyREPL3 Development Roadmap
+# Capsule Development Roadmap
 
-## Project Vision
+## Vision
 
-PyREPL3 intends to evolve beyond traditional REPL limitations to implement a **Subprocess-Isolated Execution Service (SIES)** - a managed stateful process pool with protocol-based IPC. This positions PyREPL3 as execution infrastructure rather than just an interactive shell, enabling:
+Capsule aims to become the standard execution infrastructure for interactive development environments, computational notebooks, and AI-assisted coding tools. By combining subprocess isolation with durable state management through Resonate SDK, Capsule provides production-grade code execution with enterprise features.
 
-- **Session-Oriented RPC** instead of stateless request/response
-- **Multi-language support** through language-agnostic protocol
-- **Production deployment** with resource management and monitoring
-- **Network-native operation** via WebSocket/REST APIs
+## Current State (v0.4.0-alpha)
 
-## Current State (v0.3.0-alpha)
+Capsule is transitioning from ThreadedExecutor to AsyncExecutor architecture with Resonate SDK integration for durability and orchestration.
 
-PyREPL3 has successfully implemented a thread-based execution model that enables rich interactive code execution:
+### Foundation Phase Status
+- ✅ Protocol layer with message framing
+- ✅ Session management with pooling
+- ✅ ThreadedExecutor for blocking operations
+- 🚧 AsyncExecutor implementation (in progress)
+- 🚧 Resonate SDK integration (planned)
+- ❌ Top-level await support (designed, not implemented)
+- ❌ Full capability system (specified, not built)
 
-### ✅ Input Handling (COMPLETED)
-**Implementation**: Thread-based execution model following exec-py pattern
-- User code runs in dedicated threads where blocking operations are natural
-- Protocol-based INPUT/INPUT_RESPONSE messages bridge thread-to-async communication  
-- ThreadedExecutor class (`src/subprocess/executor.py`) manages thread lifecycle
-- Non-blocking execution via `asyncio.create_task` prevents message loop deadlock
-- Full support for input(), multiple sequential inputs, and input in functions
+## Phase 1: Core Foundation (Q1 2025)
 
-**Technical Details**:
-- `ThreadSafeOutput` class redirects stdout/stderr from thread to async transport
-- `create_protocol_input()` creates thread-safe input function using `asyncio.run_coroutine_threadsafe`
-- Threading events coordinate between sync thread code and async message handlers
-- Preserves single-reader invariant preventing stdin race conditions
+### 1.1 AsyncExecutor Implementation
+**Goal**: Complete async-first execution with intelligent routing
 
-### ❌ Remaining Issues
-- **Session pool deadlocks** on the third concurrent acquisition
-- **No API layer exists** for network access
+**Deliverables**:
+- Execution mode detection (AST analysis)
+- PyCF_ALLOW_TOP_LEVEL_AWAIT integration
+- Coroutine lifecycle management
+- Thread pool for blocking I/O
 
-## Near-term Baseline (v0.3.0)
+**Success Metrics**:
+- All execution modes working
+- <5ms overhead for routing
+- 95% test coverage
 
-With input handling complete, the remaining implementations will establish:
-- Fixed pool concurrency without deadlocks
-- Basic WebSocket and REST API for network access
+### 1.2 Resonate SDK Integration
+**Goal**: Enable durability and distributed execution
 
-This will establish the **Minimum Viable Product** with full interactive capabilities.
+**Deliverables**:
+- Local mode (zero dependencies)
+- Remote mode (with server)
+- Promise-based correlation
+- Automatic crash recovery
 
-## Phase 1: Core Feature Completion (Q1 2025)
+**Success Metrics**:
+- <5% overhead in local mode
+- Recovery time <1 second
+- Promise resolution <10ms
 
-The unified planning document specified several features that exist only as message types or stubs. These must be implemented to fulfill the original vision.
+### 1.3 Namespace Management
+**Goal**: Thread-safe, durable namespace with merge-only policy
 
-### 1.1 Async Code Execution Support
-**Current State**: Standard exec() model supports async function definitions and asyncio.run()
+**Deliverables**:
+- Engine internals preservation
+- Merge strategies (user vs engine)
+- Durable persistence via promises
+- Thread-safe operations
 
-**Planned Enhancement**: Top-level await support
-- AST analysis to detect await/async constructs
-- Automatic wrapping in async context when needed
-- Reuse worker event loop instead of creating new ones
-- Would distinguish PyREPL3 from IPython's heuristic approach
+**Success Metrics**:
+- Zero KeyError failures
+- Namespace operations <100μs
+- State recovery working
 
-**Implementation Path**:
-- Detect async code via AST walk
-- Choose execution path: thread for sync, event loop for async
-- Maintain namespace compatibility between both modes
+## Phase 2: Capability System (Q2 2025)
 
-### 1.2 Transaction Support
-**Current State**: TransactionPolicy enum exists, messages support transaction_id, but no actual implementation
+### 2.1 Core Capabilities
+**Goal**: Injectable functions for common operations
 
-**Implementation Path**:
-- Implement the TransactionContext class as specified in unified plan (lines 349-366)
-- Add namespace snapshotting with copy.deepcopy
-- Wire transaction_policy parameter through execution flow
-- Handle rollback on exceptions
+**Built-in Capabilities**:
+- Input/Output operations
+- File system access
+- Network requests (HTTP/WebSocket)
+- Database queries
+- Display/visualization
 
-**Key Decisions**:
-- Memory limits for snapshot size (prevent OOM on large namespaces)
-- Snapshot compression for large states
-- Transaction nesting policy (disallow initially)
+**Architecture**:
+- Dependency injection via Resonate
+- Security policy enforcement
+- Promise-based responses
+- HITL (Human-In-The-Loop) support
 
-**Unknowns**:
-- Performance impact with scientific computing libraries (numpy arrays, pandas DataFrames)
-- Interaction with external resources (files, network connections)
+### 2.2 Security Framework
+**Goal**: Capability-based security model
 
-### 1.2 Checkpoint/Restore System
-**Current State**: CheckpointMessage and RestoreMessage defined but handlers are empty stubs
+**Features**:
+- Security levels (SANDBOX to UNRESTRICTED)
+- Runtime capability injection
+- Audit logging
+- Resource limits per capability
 
-**Implementation Path**:
-- Implement multi-tier serialization exactly as specified (lines 303-338 of unified plan)
-- Complete the create_checkpoint() method with cloudpickle → msgpack → JSON fallback
-- Add checkpoint storage layer (start with filesystem)
-- Implement restore with namespace reconstruction
+### 2.3 Custom Capabilities
+**Goal**: SDK for extending functionality
 
-**Key Decisions**:
-- Storage location (configurable path vs. fixed)
-- Checkpoint lifecycle (auto-cleanup, versioning)
-- Compression threshold (plan specifies 1MB)
+**Deliverables**:
+- Capability base classes
+- Registration system
+- Documentation and examples
+- Testing framework
 
-**Unknowns**:
-- Compatibility across Python versions
-- Handling of active resources (threads, file handles)
-- Integration with transaction snapshots (shared mechanism?)
+## Phase 3: Production Features (Q3 2025)
 
-### 1.3 FD Separation
-**Current State**: Not implemented - protocol uses stdin/stdout directly
-
-**Background**: exec-py implemented FD separation successfully, avoiding stdin conflicts
-
-**Implementation Path**:
-- Create dedicated pipe pairs for protocol communication
-- Pass FD numbers via PYREPL_PROTOCOL_FDS environment variable
-- Preserve exact FD numbers with pass_fds
-- Add compatibility flag for environments without FD passing
-
-**Key Decisions**:
-- Default behavior (opt-in vs. opt-out)
-- Windows support strategy (named pipes?)
-- Fallback mechanism robustness
-
-**Unknowns**:
-- Container environment compatibility
-- Performance difference vs. current approach
-- Impact on debugging/logging
-
-## Phase 2: Production Hardening (Q2 2025)
-
-The unified plan specified performance targets and resource limits that aren't yet enforced.
-
-### 2.1 Resource Management
-**Specified Limits** (from unified plan lines 391-399):
-- Memory: 512MB per session
-- CPU: 1 core per session  
-- Execution timeout: 30s
-- File descriptors: 100 per session
-
-**Implementation Path**:
-- Use psutil (already imported) for monitoring
-- Implement hard limits with subprocess resource controls
-- Add graceful degradation as specified
-- Create resource cleanup on limit exceeded
-
-**Key Decisions**:
-- Enforcement mechanism (SIGTERM vs. exception)
-- Warning thresholds (80% of limit?)
-- Resource reservation vs. limits
-
-### 2.2 Health Monitoring
-**Current State**: HeartbeatMessage exists but underutilized
-
-**Implementation Path**:
-- Implement automatic restart on crash (specified line 477)
-- Add /proc/{pid}/status memory monitoring (line 488)
-- Create health aggregation in manager
-- Add circuit breaker for failing sessions
-
-**Key Decisions**:
-- Health check frequency vs. overhead
-- Restart policy (immediate, backoff, circuit break)
-- Metric retention period
-
-### 2.3 Error Handling Enhancement
-**Specified Pattern** (from planning doc):
-```
-what: What went wrong
-why: Why it happened  
-how: How to fix it
-code: ErrorCode enum
-```
-
-**Implementation Path**:
-- Create structured error types
-- Add error code enumeration
-- Implement fix suggestions
-- Add error recovery actions
-
-## Phase 3: Performance Achievement (Q3 2025)
-
-The unified plan specified ambitious performance targets that require optimization.
-
-### 3.1 Meeting Latency Requirements
-**Specified Targets** (lines 372-379):
-- Simple expression: 2ms target, 5ms maximum
-- Print to client: 5ms target, 10ms maximum
-- Session acquisition (warm): 10ms target, 100ms maximum
-
-**Current Reality**: Likely 10-50ms for simple operations
+### 3.1 Performance Optimization
+**Target Metrics**:
+- Simple execution: 2ms (5ms max)
+- Top-level await: 5ms (10ms max)
+- Session acquisition: 10ms (100ms max)
+- Throughput: 1000 ops/sec per session
 
 **Optimization Areas**:
-- Protocol serialization (MessagePack vs. alternatives)
-- Frame buffering strategy
-- Output batching (currently 0.001s delay)
+- AST caching
+- Promise batching
 - Connection pooling
+- Output streaming
 
-### 3.2 Throughput Targets
-**Specified Requirements** (lines 384-389):
-- 1000 operations/second per session
-- 100 concurrent sessions per manager
-- 10MB/s streaming output bandwidth
+### 3.2 Monitoring & Observability
+**Features**:
+- Prometheus metrics
+- OpenTelemetry tracing
+- Health check endpoints
+- Performance profiling
 
-**Implementation Path**:
-- Benchmark current performance
-- Profile bottlenecks
-- Optimize hot paths
-- Consider io_uring for Linux
-
-### 3.3 Pool Efficiency
-**Specified Target**: >80% pool hit rate after warmup
-
-**Implementation Path**:
-- Implement metrics collection as specified
-- Add predictive pre-warming
-- Optimize warmup code execution
-- Add session templates
+### 3.3 Resource Management
+**Limits & Controls**:
+- Memory: 512MB per session (configurable)
+- CPU: Core affinity options
+- Execution timeout: 30s default
+- File descriptors: 100 per session
 
 ## Phase 4: Advanced Features (Q4 2025)
 
-Beyond the unified plan's scope, these features would differentiate PyREPL3.
+### 4.1 Distributed Execution
+**Goal**: Multi-node execution via Resonate
 
-### 4.1 Collaborative Sessions
-Multiple users in same session (not in original plan)
+**Features**:
+- Session migration
+- Distributed promises
+- Cross-node capabilities
+- Load balancing
 
-**Design Considerations**:
-- Operational transformation for code sync
-- Permission model
-- Conflict resolution
-- Output attribution
+### 4.2 Checkpoint & Time Travel
+**Goal**: Advanced state management
 
-### 4.2 Notebook Support
-Jupyter compatibility (mentioned but not specified)
+**Features**:
+- Automatic checkpointing
+- State snapshots
+- Time-travel debugging
+- Checkpoint sharing
 
-**Implementation Path**:
-- .ipynb file format support
+### 4.3 Notebook Integration
+**Goal**: Jupyter-compatible kernel
+
+**Features**:
+- Kernel protocol support
+- Rich output types
 - Cell execution model
-- Rich output types (images, HTML)
-- Kernel protocol compatibility
+- Magic commands
 
-### 4.3 Language Plugins
-Beyond Python execution (future vision)
+## Phase 5: Ecosystem (Q1 2026)
 
-**Possibilities**:
-- JavaScript via Node subprocess
-- SQL execution with database connections
-- Shell command execution
-- R statistical computing
+### 5.1 Language Plugins
+**Target Languages**:
+- JavaScript/TypeScript (Node.js)
+- Go
+- Rust
+- SQL
 
-## Phase 5: Ecosystem Integration (2026)
+**Architecture**:
+- Language-specific workers
+- Common protocol
+- Shared session management
+- Cross-language calls
 
-### 5.1 Deployment Patterns
-- Kubernetes operator
-- Docker compose templates
-- Systemd service files
-- Cloud formation templates
-
-### 5.2 Monitoring Integration
-- Prometheus metrics
-- OpenTelemetry traces
-- CloudWatch/Datadog adapters
-- Grafana dashboards
-
-### 5.3 Client Libraries
-- Python SDK
-- JavaScript/TypeScript client
-- Go client library
+### 5.2 Client Libraries
+**SDKs**:
+- Python (async/sync)
+- JavaScript/TypeScript
+- Go
+- REST API client
 - CLI tool
 
-## Technical Debt from Initial Implementation
+### 5.3 Deployment Patterns
+**Infrastructure**:
+- Kubernetes operator
+- Docker images
+- Helm charts
+- Terraform modules
+- Cloud-native integrations
 
-### Resolved Issues
-- **Input handling**: ✅ Thread-based execution model successfully implemented
-- **Sync/async bridge**: ✅ Clean separation between user code (threads) and infrastructure (async)
+## Phase 6: AI Integration (Q2 2026)
 
-### Immediate Cleanup Needed
-- **Type safety**: 13+ type errors in current code
-- **Message routing**: Per-execution queues are fragile (acknowledged in plan)
-- **Worker lifecycle**: No graceful degradation implemented
-- **Testing gaps**: No integration tests for full flow (though threading tests exist)
+### 6.1 LLM-Optimized Features
+**Goal**: First-class support for AI coding assistants
 
-### Architectural Improvements
-- **Session/Manager split**: Currently conflated (noted in analysis)
-- **Protocol layer confusion**: MessageTransport vs PipeTransport unclear
-- **Missing abstractions**: No sandbox protocol like pyrepl2 had
+**Features**:
+- Streaming execution for real-time feedback
+- Partial code execution
+- Semantic checkpoints
+- Error recovery suggestions
 
-### Quality Improvements
-- Error handling is minimal
-- Logging is inconsistent
-- No performance benchmarks
-- Documentation is sparse
+### 6.2 Agent Framework
+**Goal**: Autonomous code execution agents
 
-## Research Questions
+**Features**:
+- Multi-step execution plans
+- Tool use via capabilities
+- Memory management
+- Safety constraints
 
-### From Unified Planning Gaps
-1. **Input Override Approach**: ✅ RESOLVED - Thread-based execution with protocol messages proved safe and effective
-2. **Checkpoint Portability**: How to handle platform-specific objects?
-3. **Transaction Boundaries**: Should transactions span multiple executions?
+## Technical Priorities
 
-### Scaling Questions
-1. **Distributed Sessions**: Can sessions migrate between hosts?
-2. **Checkpoint Sharing**: Can checkpoints be shared across sessions?
-3. **Code Caching**: Should compiled code be cached across sessions?
+### Immediate (This Sprint)
+1. Add async wrapper to ThreadedExecutor
+2. Fix message protocol completeness
+3. Implement namespace merge-only policy
+4. Create AsyncExecutor skeleton
 
-### Integration Questions
-1. **Kernel Protocol**: Should we support Jupyter kernel protocol?
-2. **LSP Support**: Value of Language Server Protocol integration?
-3. **DAP Integration**: Debug Adapter Protocol for debugging support?
+### Short-term (Next Month)
+1. Complete AsyncExecutor with routing
+2. Add execution mode detection
+3. Implement promise abstraction
+4. Basic Resonate integration
+
+### Medium-term (Next Quarter)
+1. Full capability system
+2. Production monitoring
+3. Performance optimization
+4. Client SDKs
 
 ## Success Metrics
 
-### Current Achievement (v0.3.0-alpha)
-- ✅ input() works without EOFError - Thread-based execution fully operational
-- ❌ 3+ concurrent sessions without deadlock - Pool concurrency issue remains
-- ❌ WebSocket clients can connect and execute code - API layer not implemented
+### Technical Metrics
+- Code coverage >90%
+- Performance targets met
+- Zero critical security issues
+- Recovery success rate >99%
 
-### Post-Fix Baseline (v0.3.0)
-- ✅ input() works for all interactive scenarios
-- 3+ concurrent sessions without deadlock  
-- WebSocket clients can connect and execute code
+### Adoption Metrics
+- 100+ GitHub stars
+- 10+ production deployments
+- 5+ language plugins
+- Active contributor community
 
-### Phase 1 Completion
-- Transactions can rollback on failure
-- State can be checkpointed and restored
-- All specified message types are functional
+### Quality Metrics
+- <24 hour critical bug fix
+- <1 week feature turnaround
+- API stability (no breaking changes)
+- Documentation completeness
 
-### Phase 2 Completion
-- Resource limits enforced reliably
-- Automatic recovery from crashes
-- Production monitoring in place
-
-### Phase 3 Completion
-- Meet all latency targets from unified plan
-- Achieve throughput requirements
-- Pool efficiency >80%
-
-### Phase 4 Completion
-- Feature parity with Jupyter for basic use cases
-- Collaborative editing functional
-- 3+ language plugins working
-
-## Risk Assessment
+## Risk Mitigation
 
 ### Technical Risks
-1. **Serialization Complexity**: Multi-tier approach may have edge cases
-   - Mitigation: Extensive test matrix, clear fallback rules
+- **Complexity**: Modular architecture, comprehensive testing
+- **Performance**: Continuous benchmarking, optimization sprints
+- **Compatibility**: Version negotiation, graceful degradation
 
-2. **Performance Targets Unrealistic**: 2ms latency may be unachievable
-   - Mitigation: Set realistic targets based on benchmarks
-
-3. **Pool Complexity**: More concurrency issues may emerge
-   - Mitigation: Formal verification of pool logic?
-
-### Architecture Risks
-1. **Protocol Lock-in**: Current design may limit evolution
-   - Mitigation: Version negotiation from start
-
-2. **Subprocess Overhead**: One process per session may not scale
-   - Mitigation: Investigate thread-based alternative
-
-3. **Message Routing**: Current pattern may hit limits
-   - Mitigation: Redesign before v1.0
-
-## Next Steps
-
-With input handling complete via thread-based execution:
-
-### Immediate Priorities (Remaining Fixes)
-1. **Fix session pool deadlocks** - Debug concurrent acquisition issue
-2. **Implement API layer** - WebSocket and REST endpoints for network access
-
-### After All Fixes Complete
-1. **Validate system thoroughly** - Comprehensive test suite for threading model
-2. **Benchmark baseline** - Measure actual vs. specified performance  
-3. **Document API** - Enable early adopters with interactive examples
-4. **Create examples** - Show real-world interactive usage patterns
-
-### Quick Wins
-1. **Basic transaction support** - Simplest feature to add
-2. **Filesystem checkpoints** - Most user value
-3. **Resource monitoring** - Critical for production
-4. **Structured errors** - Improve debugging
-
-### Foundation Work
-1. **Performance benchmark suite** - Track improvements
-2. **Integration test framework** - Prevent regressions
-3. **Client SDK** - Python package for API access
-4. **Deployment guide** - Production setup docs
-
-## Technical Positioning
-
-PyREPL3 intends to occupy a specific technical niche between heavyweight container orchestration and lightweight thread pools:
-
-- **More isolated than**: Thread pools, async executors, in-process REPLs
-- **More lightweight than**: Docker containers, Kubernetes pods, VMs
-- **More stateful than**: Serverless functions, traditional RPC, job queues
-- **More managed than**: Raw subprocess spawning, basic process pools
-
-This positions PyREPL3 as infrastructure for building interactive development tools, computational notebooks, and execution services that require both isolation and persistent state.
+### Adoption Risks
+- **Learning Curve**: Examples, tutorials, documentation
+- **Migration Path**: Compatibility layers, migration tools
+- **Competition**: Unique features, better performance
 
 ## Conclusion
 
-PyREPL3's architecture is fundamentally sound, following lessons from exec-py and pyrepl2. With input handling successfully implemented via thread-based execution, one of three critical issues is resolved. The path forward is clear:
+Capsule is positioned to become critical infrastructure for the next generation of development tools. By combining subprocess isolation with durable execution via Resonate SDK, Capsule provides unique value that existing solutions cannot match.
 
-1. **Complete the subprocess-isolated execution service** - Fix pool deadlocks, implement API layer
-2. **Realize session-oriented RPC vision** - Transactions, checkpointing, restore
-3. **Enable multi-language support** - Abstract worker interface, language-specific implementations
-4. **Build production infrastructure** - Resource management, monitoring, deployment patterns
-5. **Create ecosystem** - Client SDKs, integrations, deployment tools
+The roadmap prioritizes:
+1. **Foundation**: Solid async architecture
+2. **Durability**: Resonate integration
+3. **Capabilities**: Extensible functionality
+4. **Production**: Enterprise features
+5. **Ecosystem**: Multi-language support
+6. **Innovation**: AI-first features
 
-The architecture's 70/30 split between language-agnostic infrastructure and language-specific workers positions PyREPL3 to eventually support multiple programming languages while maintaining consistent session management, pooling, and API interfaces.
-
-This roadmap should be updated quarterly based on:
-- Actual performance measurements
-- User feedback and use cases
-- Technical discoveries during implementation
-- Ecosystem evolution and standards
-
-The immediate focus must be on fixing the two remaining blocking issues (pool deadlocks and API layer), then systematically implementing the unified plan's vision before expanding scope. The successful thread-based execution model for input handling provides a solid foundation for rich interactive features.
+This roadmap will be reviewed monthly and updated quarterly based on user feedback, technical discoveries, and ecosystem evolution.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PyREPL3 - Advanced Python REPL with subprocess isolation."""
+"""Capsule - Advanced Python REPL with subprocess isolation."""
 
 from __future__ import annotations
 
@@ -189,7 +189,7 @@ async def demo_transactions() -> None:
 
 async def main() -> None:
     """Main entry point."""
-    print("PyREPL3 - Advanced Python REPL System")
+    print("Capsule - Advanced Python REPL System")
     print("=" * 40)
     
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "pyrepl3"
+name = "capsule"
 version = "0.1.0"
 description = "Advanced Python REPL with subprocess isolation and session management"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Complete project-wide renaming from PyREPL3 to Capsule for consistency and branding.

## Changes
- Update package name in `pyproject.toml` to "capsule"
- Rename all references in documentation (README, ROADMAP, CHANGELOG)
- Update copyright attribution in LICENSE
- Update main.py docstrings and output
- Update review criteria with new project name
- Ensure consistency across all user-facing text

## Impact
This is a non-breaking change for functionality but updates:
- Package name for future PyPI releases
- Documentation for clarity
- Project branding throughout

## Test Plan
- [x] Verify package builds with new name
- [x] Check all documentation references updated
- [ ] Ensure no remaining PyREPL3 references in critical files
- [ ] Verify tests still pass

## Notes
There may be additional PyREPL3 references in test files and deeper documentation that can be updated in a follow-up PR. This PR focuses on the primary user-facing references.