### PR TITLE
fix(async_executor): thread-safe telemetry, idempotent cancel, robust direct cancel; stronger tests

### DIFF
--- a/docs/async_capability_prompts/current/25_spec_api_reference.md
+++ b/docs/async_capability_prompts/current/25_spec_api_reference.md
@@ -641,6 +641,7 @@ def cancel_current(self, *, reason: str | None = None) -> bool
 **Behavior:**
 - Scope: Cancels only the task created by the executor for top‑level await or the AST wrapper; it does not enumerate or cancel user tasks.
 - Thread‑safety: If called from a non‑event‑loop thread, cancellation is scheduled via `loop.call_soon_threadsafe(task.cancel)` and returns immediately (non‑blocking). When called on the loop thread, it returns the boolean result of `task.cancel()`.
+- Telemetry: Increments `cancels_requested`; increments `cancels_effective` on success, or `cancels_noop` when nothing is running. Telemetry updates are thread‑safe (internal lock) to ensure deterministic counters under concurrent requests. Off‑loop, “effective” denotes that scheduling was enqueued, not that cancellation has already taken effect.
 - Telemetry: Increments `cancels_requested`; increments `cancels_effective` on success, or `cancels_noop` when nothing is running.
 - Exception notes: If cancellation propagates, `CancelledError` includes `execution_id`, execution mode, `cancel_reason` (when provided), `cancel_requested_at` timestamp, and a short code snippet.
 


### PR DESCRIPTION
PR A — Executor polish\n\n- Thread-safe telemetry: guard cancel counters with a lock to avoid lost updates under concurrency.\n- Idempotent cancel: repeat calls to cancel_current() return False; telemetry separates effective vs noop.\n- Robust on-loop cancel: wrap task.cancel() in try/except and log debug failures.\n- Tests: strengthen concurrent cancel invariant and add double-cancel idempotence test; keep cross-thread coverage.\n- Docs: API reference clarifies telemetry lock and off-loop "effective" semantics.\n\nAll unit tests pass locally (198 passed, 2 skipped).