### PR TITLE
fix(worker): cooperative cancel check + enable blocking I/O/input cancel tests

### DIFF
--- a/src/subprocess/worker.py
+++ b/src/subprocess/worker.py
@@ -203,6 +203,11 @@ class SubprocessWorker:
 
             await asyncio.sleep(0.01)  # Check every 10ms
 
+        # Final check: thread may have finished in the last window
+        if thread and not thread.is_alive():
+            logger.info(f"Thread finished after grace window for {execution_id}")
+            return True
+
         # Grace period expired, need hard cancel
         logger.warning(
             "Grace period expired, hard cancel required",


### PR DESCRIPTION
PR B — Worker cancel improvements\n\n- Improve cooperative cancel success detection by checking thread liveness after the grace window to avoid TOCTOU misreporting.\n- Re-enable blocking I/O hard-cancel test and cancel-during-input test.\n- Update test helpers to treat CancelledError as expected during cancellation.\n\nFocused test runs:\n- Blocking I/O cancel: passed\n- Cancel during input: passed\n- Immediate interrupt and pool recovery: passed\n\nNo executor functional changes in this PR; scope limited to worker + feature tests.