### PR TITLE
docs(refs): restore key specs to master for @-fuzzy access

### DIFF
--- a/FOUNDATION_FIX_PLAN.md
+++ b/FOUNDATION_FIX_PLAN.md
@@ -1,0 +1,1124 @@
+# Foundation Fix Plan: Building Solid Ground Before Full Spec Implementation
+
+> Status Update (2025-09-05)
+
+- Phase 0: COMPLETE — Emergency fixes
+- Phase 1: COMPLETE — AsyncExecutor core with TLA, AST fallback, routing, blocking I/O detection, DI factory
+- Phase 1b: COMPLETE — AsyncExecutor refinements (namespace binding fixed, enhanced detection, configurability, telemetry, compile flags)
+- Phase 2a: COMPLETE — Resonate vertical slice (experimental proof-of-concept)
+- Phase 2b: COMPLETE — Promise-first durable flow + bridge correlation + session interceptors
+- Phase 2c: COMPLETE (local-mode stabilization) — Minimal checkpoint/restore handlers; output-before-result; Busy guard
+- Phase 3-6: TODO — Full implementation (~3-4 weeks to production)
+
+Changelog Practice (Phase 3): After each Phase 3 PR is validated and accepted, append a brief entry to `docs/PHASE_3_CHANGELOG.md` summarizing the behavior changes, tests, and decisions. This keeps implementation and plan aligned for reviewers.
+
+**Current PR #12 Status**: Phase 1 + Phase 2a delivered; Phase 2b/2c updates landed
+- Unit and integration tests pass in local mode; CI validates on PRs.
+- Durable functions are promise‑first; Session is the sole transport reader; worker supports checkpoint/restore with merge‑only default and `clear_existing` support.
+- Bridge correlation, timeouts, and race handling implemented; Input capability payload mapping aligned to protocol.
+
+## Progress Update — Phase 2b and Early 2c (2025-09-05)
+
+### What’s Landed (Phase 2b)
+
+- Promise-first durable flow
+  - `durable_execute` now uses `ctx.promise(id=f"exec:{execution_id}")` and `ResonateProtocolBridge.send_request("execute", ...)`.
+  - No asyncio usage in durable functions; no loop creation or spinning.
+  - Deterministic promise id format: `exec:{execution_id}`. Timeout propagates from `ctx.config.tla_timeout`.
+  - Robust payload handling: parse `ResultMessage`/`ErrorMessage` JSON; fall back to `repr` when value not serializable; add structured context on errors via `add_note` when available.
+
+- Protocol Bridge correlation
+  - Execute → Result/Error: maps `ExecuteMessage.id` (used as worker execution_id) to durable promise id; resolves on `ResultMessage.execution_id` or `ErrorMessage.execution_id`.
+  - Input → InputResponse: already implemented; verified and covered by tests.
+  - Single mapping source of truth (`_pending`); cleaned up on resolve/reject paths.
+
+- Single-loop ownership via interceptors
+  - Added `Session.add_message_interceptor()` / `remove_message_interceptor()`.
+  - Interceptors invoked inside the session `_receive_loop` (single call site) before routing; designed to be passive and non-blocking.
+  - `initialize_resonate_local(session, resonate=...)` registers `ResonateProtocolBridge.route_response` as an interceptor for `Result`, `Error`, and `InputResponse`.
+  - Bridge uses the session to send messages; it never reads from the transport.
+  - Routing tasks are scheduled via `create_task`, tracked with done-callback logging, and cancelled on session termination.
+
+- Capability/Input consistency
+  - `InputCapability` remains promise-based; now uses the same bridge + promise namespace (constructor `(resonate, bridge)`).
+  - Uniform id format for input promises (`{execution_id}:input:{message.id}` handled by bridge).
+  - Payload mapping aligned to protocol: prefer `InputResponseMessage.data`; legacy fallback to `{ "input": ... }` tolerated.
+
+- Tests
+  - Unit coverage added for: bridge execute/result/error correlation; interceptor registration/invocation; durable promise-first generator behavior; input capability JSON handling.
+  - Updated local init and input capability tests to new DI and constructor shapes.
+
+### What’s Landed (early Phase 2c)
+
+- Worker lifecycle and result
+  - Confirmed last-expression result delivery, JSON-safe `value` with fallback `repr`, and always set `execution_time`.
+  - Verified output-before-result ordering by draining outputs before sending `ResultMessage` (existing behavior retained).
+  - Restart after crash integration test now passes; reset the session cancellation event on `start()`.
+
+- Minimal checkpoint/restore handlers (local mode)
+  - Worker handles `CheckpointMessage`: creates in-memory snapshot via `CheckpointManager`, responds with `CheckpointMessage` populated with `data` and counts; also emits a `ReadyMessage` for simple confirmation.
+  - Worker handles `RestoreMessage`: accepts `checkpoint_id` or inline `data`; applies merge-only namespace restoration by default and replies with `ReadyMessage` (duplicated for sync robustness in tests).
+  - Merge-only semantics by default: never replace the namespace mapping object; preserve `ENGINE_INTERNALS`. With `clear_existing=True`, clear non-internal keys and reinitialize engine internals before restore.
+
+### Architecture Alignment
+
+- Single‑loop invariant enforced: only the Session reads the transport. Tests observe via session APIs/interceptors; no competing readers remain in integration tests.
+
+- Bridge interceptor scheduling
+  - Interceptors must be non-blocking. The bridge’s `route_response` is async; we will schedule it via `asyncio.create_task` on the session loop instead of calling it inline. Current code invokes it synchronously; unit tests pass because they don’t exercise the async path, but this will be adjusted.
+
+- Error payload handling in durable function
+  - Current behavior returns `{"result": None, ...}` when the promise resolves with an error payload; alternatively, raising a structured `RuntimeError` is acceptable. Tests accept both; the spec prefers rejecting/raising on error. Next step: ensure bridge rejects the durable promise on `ErrorMessage` to standardize raising behavior.
+
+### Problems Encountered and Solutions
+
+- Multiple readers on the transport (test conflict)
+  - Problem: Integration test raced the session receive loop by reading directly from the transport.
+  - Solution: preserve single-loop ownership; add interceptors for passive observation; emit additional `ReadyMessage` from the worker to improve sync in tests. Recommendation: update tests to use interceptors/session APIs.
+
+- Event loop lifecycle after restart
+  - Problem: lingering cancellation event caused immediate cancels post-restart.
+  - Solution: reset `_cancel_event` in `Session.start()`; worker lifecycle tests now pass.
+
+- Durable async handling in interceptors
+  - Problem: `route_response` is async but interceptors must remain passive.
+  - Solution (planned): schedule `bridge.route_response(message)` with `asyncio.create_task()` on the session loop; avoid blocking.
+
+### Work Remaining
+
+- Promise-first (Phase 2b)
+  - Schedule `route_response` from interceptors; ensure strict cleanup on resolve/reject and add contextual timeout exceptions (`add_note` with request id/type/timeout).
+  - Standardize durable error path: reject the promise on `ErrorMessage` and raise in durable code; add unit coverage.
+
+- Integration stabilization (Phase 2c)
+  - Checkpoint/restore: finalize response shape; add round-trip tests that assert merge-only semantics via session APIs (not direct transport reads).
+  - Output chunking and ordering: add integration tests for long lines and carriage-return progress; keep “output-before-result” strict.
+  - Concurrent safety: enforce one in-flight execution per worker; deterministic error/backpressure on overlapping executes; tests for cross-talk prevention.
+  - Transport ownership: provide a session-level observer hook for non-execution messages to replace direct transport reads in tests.
+
+### Implications
+
+- The single-loop invariant is now enforced in code paths (bridge never reads; only session does). Tests that bypass the session loop will be racy; moving to interceptors/session APIs is necessary for reliability.
+- Promise-first architecture removes loop-spinning hazards from durable functions and clarifies correlation; this sets the foundation for remote/distributed orchestration.
+- The minimal checkpoint/restore in worker unblocks local-mode roundtrip testing, with room to refine response semantics and namespace merge fidelity under load.
+
+Next steps (Phase 2 preview):
+- Address integration failures (worker last‑expression result delivery, large output handling, checkpoint create/restore, concurrent executions, transport backpressure/drain ordering).
+- Enforce single‑loop ownership (executor/transport); remove any loop‑spinning in durable functions.
+- Add configurability + telemetry for blocking I/O detection.
+- Add perf guardrails (TLA latency micro‑benchmarks) and documentation polish for DI usage.
+
+— The legacy status block below reflects the original plan context prior to this update.
+
+**STATUS**: Day 4+ Complete (Phase 0 Emergency Fixes + All PR Review ✅) | Test Pass Rate: 97.9% (94/96 unit tests)
+**BRANCH**: `fix/foundation-phase0-emergency-fixes` (Days 1-4 work, PR #10 ready to merge)
+
+## Updated Roadmap & PR Split (2025-09-05)
+
+This section supersedes older mixed notes below. It defines a clear split between the AsyncExecutor core and the Resonate integration.
+
+### Roadmap Summary (Updated)
+
+| Phase | Scope | Status | Timeline |
+| - | - | - | - |
+| Phase 0 | Emergency fixes: ThreadedExecutor async wrapper, protocol fixes, namespace merge-only | COMPLETE | ✅ |
+| Phase 1 | AsyncExecutor core: TLA + AST fallback, routing, blocking I/O detection, DI factory | COMPLETE | ✅ |
+| Phase 1b | AsyncExecutor refinements: namespace binding fixes, enhanced blocking I/O, caching | COMPLETE | ✅ |
+| Phase 2a | Resonate vertical slice: basic durable_execute, minimal bridge, InputCapability | COMPLETE | ✅ |
+| Phase 2b | Promise-first refinement: ctx.promise pattern, complete protocol bridge | COMPLETE | ✅ |
+| Phase 2c | Integration stabilization: worker/session fixes, checkpoint/restore | COMPLETE (local mode) | ✅ |
+| Phase 3 | Full AsyncExecutor: EventLoopCoordinator, CoroutineManager, Cancellation, true async | TODO | 3-4 days |
+| Phase 4 | Full capability system: File, Network, complete HITL, security policies | TODO | 3-4 days |
+| Phase 5 | Remote & production: server support, retry logic, MigrationAdapter | TODO | 3-4 days |
+| Phase 6 | Performance & observability: benchmarks, OpenTelemetry, metrics | TODO | 2-3 days |
+
+### PR: async-executor-core (Phase 1)
+
+- Deliverables:
+  - AsyncExecutor with top-level await (eval-first using `PyCF_ALLOW_TOP_LEVEL_AWAIT = 0x2000`), `CO_COROUTINE` detection, `asyncio.timeout(tla_timeout)`.
+  - AST fallback (def→async def, zero-arg lambda transform, conservative global hoisting) with locals-first merge and global-diff application.
+  - Routing and enhanced blocking I/O detection (alias-aware for time/requests/socket/os/pathlib, etc.).
+  - DI factory (`async_executor_factory`) and awaitable promise adapter.
+  - Unit CI workflow (`.github/workflows/unit-tests.yml`).
+- Non-goals (explicitly out of this PR): Resonate durable functions, protocol bridge, HITL workflows, remote orchestration, session/worker lifecycle fixes.
+- Acceptance Criteria:
+  - All unit tests for AsyncExecutor and related components pass; TLA semantics verified on direct and fallback paths; namespace merge-only policy preserved; configurable TLA timeout works.
+  - No namespace dict replacement anywhere; `ENGINE_INTERNALS` protected.
+  - CI runs unit tests on PRs (Python 3.11).
+- Test Plan:
+  - Unit: TLA expression and statements, AST fallback transformations, globals binding, result history, blocking I/O detection, timeout override.
+  - Integration: Not required for this PR (tracked for Phase 2).
+- Dependencies:
+  - None on Resonate SDK. Uses local DI only.
+- Status: COMPLETE. Core functionality implemented.
+
+### Phase 1b: AsyncExecutor Refinements (IN PROGRESS)
+
+- Deliverables:
+  - Namespace binding fixes COMPLETE (locals-first merge, then global diffs; live __globals__ under both paths)
+  - AST transform preserves module-level globals (simple global hoist) COMPLETE
+  - Enhanced blocking I/O detection (aliases + attribute chains including `time.sleep`, `requests.get/post`, `urllib.request.urlopen`, `socket.socket().recv/send/accept/connect`, `os.system`, `subprocess.run/Popen`, `pathlib.Path.read*/write*`, `open`) COMPLETE
+  - Configurable AST cache size via constructor/factory and env override (`ASYNC_EXECUTOR_AST_CACHE_SIZE`) COMPLETE
+  - Telemetry counters/logging knobs for detection COMPLETE
+  - Consider ThreadedExecutor pooling for performance (DOCUMENTED ONLY)
+  - Convert 3 XPASS tests to asserts COMPLETE
+- Acceptance Criteria:
+  - All namespace binding tests pass without XPASS (DONE)
+  - Blocking I/O detection catches common patterns (DONE)
+  - Configuration options exposed for cache size and detection modules (DONE)
+- Dependencies:
+  - Phase 1 completion
+- Status: IN PROGRESS. Unit suite green; integration unchanged (Phase 2 scope only).
+
+### Phase 2a: Resonate Vertical Slice (COMPLETE - Current PR #11)
+
+- Deliverables:
+  - Basic `durable_execute` function (using ctx.lfc workaround, NOT promise-first yet)
+  - Minimal `ResonateProtocolBridge` (only handles InputResponseMessage correlation)
+  - Single `InputCapability` implementation using promises
+  - Local-only initialization with DI wiring
+- Known Limitations:
+  - Using ctx.lfc synchronous wrapper instead of promise-first pattern
+  - Protocol bridge incomplete (no Execute/Result/Error correlation)
+  - Only one capability implemented (InputCapability)
+  - No remote mode support
+  - 2 integration tests failing (checkpoint/worker lifecycle)
+- Status: COMPLETE as experimental proof-of-concept. Production implementation in Phase 2b/2c.
+
+### Phase 2b: Promise-First Refinement (COMPLETE)
+
+- Deliverables:
+  - Replace ctx.lfc with ctx.promise pattern (avoiding event loop hazards)
+  - Complete ResonateProtocolBridge with Execute/Result/Error correlation
+  - Fix event loop ownership issues (single-loop invariant)
+  - Resolve failing integration tests
+- Acceptance Criteria:
+  - No event loop creation in durable functions
+  - All protocol messages properly correlated via promises
+  - Integration tests passing
+- Dependencies:
+  - Phase 2a completion
+- Status: COMPLETE. Critical durable flow and correlation landed.
+
+### Phase 2c: Integration Stabilization (COMPLETE in local mode)
+
+- Deliverables:
+  - Worker/session last-expression result delivery 
+  - Large output/message chunking and drain ordering
+  - Checkpoint create/restore implementation
+  - Event loop lifecycle audit and fixes
+  - Concurrent execution safety
+- Acceptance Criteria:
+  - Local‑mode durable execution works end‑to‑end (no server) using promise‑first flows; HITL round‑trips work via bridge + promise.
+  - Output ordering preserved (outputs precede Result resolution for same execution).
+  - Configurable timeouts propagate through durable functions and promises.
+- Test Plan:
+  - Unit: DI graph, durable function (promise‑first template), protocol bridge promise roundtrips and pending cleanup, HITL capability request/response including invalid JSON handling, error/timeout propagation with `add_note` context, checkpoint/restore minimal fields validation.
+  - Integration (local): durable execute promise resolution, input flow; output‑before‑result ordering; single‑loop invariant checks.
+  - Remote: mocked interface parity (no real network required for Phase 2).
+- Dependencies:
+  - Phase 2b completion
+  - Stable transport framing
+- Status: COMPLETE for local mode. Remote/performance items deferred.
+
+### Phase 3: Full AsyncExecutor Implementation (UPDATED — 3.11–3.13 research)
+
+- Deliverables:
+  - EventLoopCoordinator for proper event loop management and non‑async queuing
+  - CoroutineManager with lifecycle tracking and structured cancellation
+  - ExecutionCancellation (cooperative cancel for async paths; delegated for blocking sync)
+  - Native async execution paths (no ThreadedExecutor for TLA/async defs)
+  - Compile‑first TLA strategy using `PyCF_ALLOW_TOP_LEVEL_AWAIT` (exec/eval) with await/eval handling
+  - Minimal AST fallback wrapper only when direct compile fails; no broad refactors
+  - Blocking I/O detection refinements (attribute chains, aliasing, overshadowing) with telemetry and config
+  - Code‑object caching (LRU) keyed by `source+mode+flags` (optional AST cache only where transforms apply)
+  - Optional (flagged) symtable‑backed hoisting for top‑level imports/defs (preserve order; semantics‑safe)
+  - PEP 657 location‑mapping rules for any transforms (copy_location, fix_missing_locations)
+- Acceptance Criteria:
+  - Compile‑first path executes TLA/`async for`/`async with` across 3.11–3.13; fallback wrapper only for rare failures
+  - No “def→async def” mass transforms; lambda→async helper disabled by default (documented, guarded if retained)
+  - Transforms do not reorder user statements; locals‑first then global‑diffs applied; ENGINE_INTERNALS preserved
+  - Visitors/analyzers tolerate 3.11–3.13 nodes: Match/Patterns, TryStar, TypeAlias, and `type_params`
+  - Accurate error spans (PEP 657) for transformed code; tracebacks underline original expressions
+  - Cancellation closes/cleans pending coroutines and tasks; metrics recorded
+  - Blocking I/O detection handles alias/attribute patterns; false positives reduced by overshadowing checks
+  - Caching improves repeated execution latency; cache keys distinguish `mode` and flags; tests verify correctness
+  - Hoisting (if enabled) is semantics‑preserving on edge‑case corpus; OFF by default in Phase 3
+- Dependencies:
+  - Phase 1b completion
+- Status: TODO. Required for full async capabilities.
+
+### Phase 3: Operational and Performance Refinements (NEW)
+
+- Bounded routing task concurrency (Semaphore/TaskGroup) once we observe backpressure.
+- Interceptor performance budgets and warnings (measure call durations; structured logs on overruns).
+- Bridge lifecycle hook to cancel all pending correlations (`close()/cancel_all`) and DI shutdown wiring.
+- Convert sleep-based race tests to event-based synchronization for CI determinism.
+
+### Research‑Informed Updates (Python 3.11–3.13)
+
+- Top‑Level Await: Prefer compile‑first with `PyCF_ALLOW_TOP_LEVEL_AWAIT` for `exec` and `eval` modes; evaluate to a coroutine and `await` it. Support top‑level `async for`/`async with` without AST rewriting. Keep AST fallback wrapper solely for resilience.
+- Transform Policy (PR 3): Default to minimal wrapper only; do not rewrite user code. Broad “def→async def if contains await” and zero‑arg lambda→helper are retained but OFF by default and gated by flags. The fallback wrapper preserves order, appends `return locals()` for statements, uses locals‑first then global diffs, and binds functions to the live globals mapping.
+- Symbol‑Aware Hoisting: Behind a feature flag, use `symtable` + AST to hoist unconditional top‑level imports and defs not shadowed/rebound or conditional. Maintain original relative order. Treat `TypeAlias` as assignment‑like. Beware PEP 709 (3.12) comprehension symbols; never treat comp targets as globals.
+- PEP 657 Locations (PR 3): Use `ast.copy_location` for inserted `Return` nodes, copy end positions when available, and `ast.fix_missing_locations` post‑transform. Keep a stable fallback filename `<async_fallback>` and register original source in `linecache` for readable tracebacks.
+- AST Coverage (3.11–3.13): Ensure traversal/visitors handle `Match` + pattern subclasses, `TryStar`, `TypeAlias`, and `type_params` on defs/classes; no special handling needed for PEP 701 f‑strings beyond traversal.
+- Caching: Prefer code‑object LRU cache keyed by `(source, mode, flags)`; keep AST LRU only where transforms are applied. Optionally compile with TLA flag always (harmless when no await) to simplify keys.
+
+### Phase 4: Full Capability System (TODO)
+
+- Deliverables:
+  - Complete capability implementations (File, Network, System, etc.)
+  - Security policy enforcement at capability level
+  - Complete HITL workflows with all interaction types
+  - Capability injection framework per spec
+- Acceptance Criteria:
+  - All capabilities from spec implemented
+  - Security boundaries enforced
+  - HITL workflows fully functional
+- Dependencies:
+  - Phase 2c and Phase 3 completion
+- Status: TODO. Required for complete functionality.
+
+### Phase 5: Remote Mode & Production (TODO)
+
+- Deliverables:
+  - Remote Resonate server support
+  - Connection management and retry logic
+  - MigrationAdapter for incremental adoption
+  - Production hardening (graceful degradation, circuit breakers)
+  - Resource limits enforcement
+- Acceptance Criteria:
+  - Works with remote Resonate server
+  - Handles network failures gracefully
+  - Production-ready reliability
+- Dependencies:
+  - Phase 4 completion
+- Status: TODO. Required for distributed deployment.
+
+### Phase 6: Performance & Observability (TODO)
+
+- Deliverables:
+  - Performance benchmarks and CI guards
+  - OpenTelemetry integration
+  - Metrics collection and reporting
+  - Structured logging throughout
+  - Configurable detection policies
+- Acceptance Criteria:
+  - Meets performance targets (<1ms local, <10ms remote)
+  - Full observability stack integrated
+  - CI enforces performance regression prevention
+- Dependencies:
+  - Phase 5 completion
+- Status: TODO. Required for production operations.
+
+### Work Breakdown & Order (Updated)
+
+**Current Status**: PR #11 ready to merge (Phase 1 + Phase 2a vertical slice)
+
+**Immediate Next Steps (Phase 1b - 2-3 days):**
+1) Fix namespace binding issues (global diffs after locals)
+2) Enhance blocking I/O detection (attribute chains)
+3) Make AST cache configurable
+4) Fix 3 XPASS tests
+
+**Promise-First Refinement (Phase 2b - 2-3 days):**
+5) Replace ctx.lfc with ctx.promise pattern
+6) Complete protocol bridge correlation
+7) Fix event loop ownership issues
+8) Resolve integration test failures
+
+**Integration Stabilization (Phase 2c - 2-3 days):**
+9) Worker/session robustness improvements
+10) Checkpoint/restore implementation
+11) Large output handling
+
+**Full Implementation (Phases 3-6 - 3-4 weeks):**
+12) Complete AsyncExecutor implementation
+13) Full capability system
+14) Remote mode support
+15) Performance and observability
+
+### Interfaces & Dependencies
+
+- AsyncExecutor Core → Resonate: No direct dependency. Exposed via DI factory; durable functions consume factory to instantiate per-execution executors.
+- Resonate Durable Functions → Worker/Transport: Durable functions call into AsyncExecutor; protocol messages still sent via transport; promises correlate responses to waiting code.
+- HITL → Transport: Input requests sent as protocol messages; results provided by promise resolution.
+
+### Risks & Mitigations (Phase 2)
+
+- Race conditions in session/worker under high output: add orderly drain and backpressure policies; validate with large message tests.
+- Event loop misbinding: audit initialization order; ensure all asyncio objects are bound to the active loop.
+- Promise timeouts and error context: adopt `asyncio.timeout()` consistently; ensure `add_note` context includes execution id/mode.
+
+
+## Executive Summary
+
+**Last Updated**: After full spec review and deep analysis of Resonate integration patterns.
+
+After reviewing the current implementation, test failures, and **reading the full specifications in detail**, I've identified that we're in an **architectural transition phase** with a clear solution path. The specs elegantly solve the async/await vs yield paradigm through a **wrapper pattern** where Resonate wraps AsyncExecutor at the integration layer - no code transformation needed.
+
+**Phase 0 Status**: ✅ COMPLETE - AsyncExecutor skeleton implemented with proper lifecycle management, ThreadedExecutor delegation working with async wrapper, namespace merge-only policy enforced, ENGINE_INTERNALS centralized, all PR review feedback addressed. 97.6% test pass rate achieved (83/85 tests). Ready to merge to master.
+
+**Key Discovery**: The specs already solve the hard problems. Our refinements focus on making the bridge robust, testing edge cases early, and ensuring consistent behavior across local/remote modes.
+
+## Development Workflow & Branching Strategy
+
+### Phase-Based Branches
+We're using a phase-based branching approach to keep related changes together while maintaining a clean history:
+
+| Phase | Branch Name | Days | Scope | Merge Criteria |
+|-------|------------|------|-------|----------------|
+| **Phase 0** | `fix/foundation-phase0-emergency-fixes` | 1-3 | Emergency fixes to unblock testing | ✅ Tests passing (>80%) |
+| **Phase 1** | `fix/foundation-phase1-async-executor` | 4-7 | AsyncExecutor foundation | Tests passing, no regressions |
+| **Phase 2** | `fix/foundation-phase2-bridge` | 8-10 | Bridge architecture | Full integration ready |
+
+### Workflow
+```bash
+# Current work (Phase 0, Days 1-3)
+git checkout fix/foundation-phase0-emergency-fixes
+# ... implement Days 2-3 fixes ...
+git commit -m "fix: implement namespace merge-only policy"
+
+# When Phase 0 complete
+git push origin fix/foundation-phase0-emergency-fixes
+# Create PR → Review → Merge to master
+
+# Start Phase 1 (Day 4)
+git checkout master && git pull
+git checkout -b fix/foundation-phase1-async-executor
+```
+
+### Merge to Master Criteria
+- ✅ All phase goals achieved
+- ✅ Tests passing (target >80% for Phase 0, >95% for Phase 1-2)
+- ✅ No regressions from previous phase
+- ✅ Code reviewed (if team environment)
+
+## Key Files Referenced
+
+### Current Implementation
+- `src/subprocess/executor.py` - ThreadedExecutor implementation
+- `src/subprocess/worker.py` - SubprocessWorker main entry
+- `src/subprocess/namespace.py` - NamespaceManager 
+- `src/protocol/messages.py` - Pydantic message models
+- `src/session/manager.py` - Session lifecycle management
+
+### Test Files
+- `tests/unit/test_executor.py` - Executor unit tests (failing)
+- `tests/unit/test_messages.py` - Message validation tests
+- `tests/integration/test_session.py` - Session integration tests
+- `tests/features/test_cancellation.py` - Cancellation tests
+
+### Specification Documents
+- `docs/async_capability_prompts/current/00_foundation_resonate.md` - Resonate integration vision
+- `docs/async_capability_prompts/current/10_prompt_async_executor.md` - AsyncExecutor implementation guide
+- `docs/async_capability_prompts/current/20_spec_architecture.md` - Full architecture specification
+- `docs/async_capability_prompts/current/22_spec_async_execution.md` - Async execution patterns
+- `docs/async_capability_prompts/current/24_spec_namespace_management.md` - Namespace management rules
+
+## Implementation Snapshot (Local Mode)
+
+- Durable functions are promise‑first (`ctx.promise` + Protocol Bridge). No event loops are created in durable code.
+- Bridge correlates Execute/Result/Error via `execution_id` and Input/InputResponse via `input_id`; pending correlations are lock‑guarded with atomic cleanup and default timeouts.
+- Session owns the single transport read loop; interceptors run once in the receive loop; routing tasks are tracked and cancelled on shutdown; errors are logged.
+- Worker enforces output‑before‑result; on drain timeout, emits an Error and withholds Result; merge‑only namespace semantics with `clear_existing` support; `ENGINE_INTERNALS` preserved; Busy guard active.
+- Input capability uses protocol shape (`data`) with a legacy `input` fallback.
+
+## Resolved Issues
+
+- Async/sync bridging for local mode is stable via ThreadedExecutor delegation; promise‑first flow offloads transport concerns to the Session/Bridge.
+- Message protocol completeness (e.g., `execution_time`) validated in code and tests.
+- Namespace policy enforced: never replace mapping, always merge; preserve engine internals; restore honors `clear_existing`.
+- Event loop coordination: no additional loops created; all asyncio primitives bound to the Session loop; interceptors are non‑blocking.
+
+## Open Items (Phase 3+)
+
+- Native AsyncExecutor path (true async execution) and full coroutine lifecycle/cancellation.
+- Operational refinements: bounded routing concurrency; interceptor performance budgets and slow‑call warnings.
+- Bridge lifecycle: `close()/cancel_all()` to clear pending correlations; DI shutdown wiring.
+- Convert time‑based race tests to event‑based synchronization for CI determinism.
+- Capabilities: broaden beyond Input; remote mode support; performance & observability (metrics/OTel).
+
+## Resonate SDK Alignment & Key Learnings (Summary)
+
+- Environment: Python 3.13 (uv), `resonate-sdk==0.6.3` (latest as of this date).
+- Context API:
+  - `ctx.lfc` is synchronous and expects a regular (sync) function. Do not pass async callables.
+  - `ctx.lfi` returns a promise for async invocation; `yield` the promise to resume.
+  - `ctx.promise` is the preferred pattern for async/HITL durable flows.
+  - `checkpoint` is not exposed on Context in 0.6.x; use promises/dependencies to persist state until available.
+- Registration: `@resonate.register(name=..., version=int)` — version is an integer.
+- Architectural Implication: Promise‑first is required to avoid loop‑crossing hazards and to align with resilient, recoverable execution. The executor/transport own the loop; durable functions do not.
+
+### Migration Decisions
+
+1) Short term (local mode):
+   - If a sync facade is unavoidable, submit coroutines to the executor's loop via `asyncio.run_coroutine_threadsafe` and block on `.result()`; never create a new event loop in the durable layer.
+2) Long term (spec‑aligned):
+   - Move `durable_execute` to promise‑first using `ctx.promise` + `ResonateProtocolBridge` to send Execute and yield the promise for Result.
+   - Extend the bridge with deterministic correlation for Execute/Result/Error and Inputs.
+   - Enforce the single‑loop invariant across session/executor/transport.
+
+### Anti‑Patterns (Do Not Do)
+
+- Creating event loops inside durable functions (`new_event_loop`, `run_until_complete`).
+- Passing `async def` callables to `ctx.lfc`.
+- Rebinding transport/executor to multiple loops.
+
+## Prioritized Fix Plan
+
+### Phase 0: Emergency Fixes ✅ COMPLETED (Days 1-3)
+These unblock testing and development:
+
+#### 0.1 Add Async Wrapper to ThreadedExecutor ✅
+**File**: `src/subprocess/executor.py` (added at lines 627-674)
+```python
+# ACTUAL IMPLEMENTATION in ThreadedExecutor class:
+async def execute_code_async(self, code: str) -> Any:
+    """Async wrapper for compatibility with tests."""
+    # Note: Output pump should already be started by caller
+    try:
+        loop = asyncio.get_event_loop()
+        self._result = None
+        self._error = None
+        
+        # Run sync execute_code in thread pool
+        future = loop.run_in_executor(None, self.execute_code, code)
+        await future
+        
+        # Drain outputs with timeout protection for mock transports
+        try:
+            await self.drain_outputs(timeout=0.5)
+        except (OutputDrainTimeout, asyncio.TimeoutError):
+            pass  # OK in tests with mock transport
+        
+        if self._error:
+            raise self._error
+        return self._result
+    finally:
+        pass  # State reset on next execution
+```
+**Tests Fixed**: `tests/unit/test_executor.py` - All 5 tests now pass
+**Also Updated**: Tests to use `AsyncMock()` for transport.send_message
+
+#### 0.2 Fix Message Field Issues ✅
+**Files Fixed**:
+- `src/subprocess/worker.py` - NO CHANGES NEEDED (already had execution_time at lines 338, 349)
+- `tests/unit/test_messages.py` - FIXED test data
+
+```python
+# ACTUAL FIX in test_messages.py line 44:
+msg = ResultMessage(
+    id=str(uuid.uuid4()),
+    timestamp=time.time(),
+    execution_id="exec-123",
+    value=42,
+    repr="42",
+    execution_time=0.5,  # ADDED THIS FIELD
+)
+
+# ACTUAL FIX in test_messages.py lines 110-112:
+msg = HeartbeatMessage(
+    id="test-123",
+    timestamp=time.time(),
+    memory_usage=1024 * 1024,  # ADDED
+    cpu_percent=25.0,          # ADDED
+    namespace_size=10,         # ADDED
+)
+```
+**Tests Fixed**: `tests/unit/test_messages.py` - All 8 tests now pass
+
+### Phase 1: Core Foundation Fixes (1-2 days) - **READY TO START**
+**Phase 0 Complete**: AsyncExecutor skeleton ready, 97.6% tests passing, foundation stable
+
+#### 1.1 Implement Namespace Merge-Only Policy ✅ COMPLETED IN DAY 2
+**Files Modified**: `src/subprocess/namespace.py`, `src/subprocess/worker.py`
+**Spec**: `docs/async_capability_prompts/current/24_spec_namespace_management.md:87-102` (ENGINE_INTERNALS list)
+
+**Completed Implementation**:
+- Added ENGINE_INTERNALS constant with all protected keys
+- Fixed _setup_namespace() to use update() instead of replace
+- Added update_namespace() method with merge strategies (overwrite/preserve/smart)
+- Added _update_result_history() for tracking execution results (_, __, ___)
+- Updated clear() to preserve engine internals
+- Created comprehensive test suite (12 tests, all passing)
+
+#### 1.2 Create AsyncExecutor Skeleton ✅ COMPLETED IN DAY 3
+**New File**: `src/subprocess/async_executor.py` (395 lines)
+**Based On**: `docs/async_capability_prompts/current/22_spec_async_execution.md:58-144`
+**Test File**: `tests/unit/test_async_executor.py` (499 lines, 22 tests)
+
+**Completed Implementation**:
+- ExecutionMode enum with 5 modes (TOP_LEVEL_AWAIT, ASYNC_DEF, BLOCKING_SYNC, SIMPLE_SYNC, UNKNOWN)
+- PyCF_ALLOW_TOP_LEVEL_AWAIT = 0x2000 constant defined
+- AST-based code analysis with recursive await detection
+- Blocking I/O detection (requests, urllib, socket, open, etc.)
+- Event loop management with ownership tracking
+- ThreadedExecutor delegation for all non-async execution
+- Coroutine lifecycle management with weakref tracking
+- Comprehensive test coverage (91% of AsyncExecutor code)
+
+```python
+# ACTUAL IMPLEMENTATION in src/subprocess/async_executor.py:
+class AsyncExecutor:
+    """Skeleton async executor for transition to async architecture."""
+    PyCF_ALLOW_TOP_LEVEL_AWAIT = 0x1000000
+    BLOCKING_IO_MODULES = {'requests', 'urllib', 'socket', 'subprocess', ...}
+    BLOCKING_IO_CALLS = {'open', 'input', 'sleep', 'wait', ...}
+    
+    def analyze_execution_mode(self, code: str) -> ExecutionMode:
+        """AST-based execution mode detection."""
+        try:
+            tree = ast.parse(code)
+            # Check for top-level await, async defs, blocking I/O
+            if self._contains_await_at_top_level(node):
+                return ExecutionMode.TOP_LEVEL_AWAIT
+            # ... additional checks ...
+        except SyntaxError:
+            if 'await' in code:
+                return ExecutionMode.TOP_LEVEL_AWAIT
+            return ExecutionMode.UNKNOWN
+    
+    async def execute(self, code: str) -> Any:
+        mode = self.analyze_execution_mode(code)
+        if mode == ExecutionMode.TOP_LEVEL_AWAIT:
+            raise NotImplementedError("Async execution coming soon")
+        else:
+            # Delegate to ThreadedExecutor with proper async wrapper
+            return await self._execute_with_threaded_executor(code)
+```
+**Tests Passing**: All 22 AsyncExecutor tests, no regressions in existing suite
+
+#### 1.3 Fix Event Loop Management
+**File**: `src/session/manager.py` (fix lines 81-83)
+**Guidance**: `docs/async_capability_prompts/current/22_spec_async_execution.md:123-128`
+
+```python
+# In session/manager.py, replace lines 81-83:
+class Session:
+    def __init__(self, ...):
+        # Earlier in __init__, ensure consistent loop usage
+        # Get or create loop BEFORE creating asyncio objects
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
+        
+        # NOW create asyncio objects (they'll use the current loop)
+        self._lock = asyncio.Lock()  # Line 81 - now uses correct loop
+        self._ready_event = asyncio.Event()  # Line 82 - uses current loop
+        self._cancel_event = asyncio.Event()  # Line 83 - uses current loop
+```
+**Also Check**: `tests/fixtures/sessions.py:18-42` for similar issues
+
+### Phase 2: Bridge to Future Architecture (3-5 days)
+
+#### 2.1 Create Execution Mode Router
+**New Component**: Add to `src/subprocess/async_executor.py`
+**Based On**: `docs/async_capability_prompts/current/22_spec_async_execution.md:69-75, 149-247`
+
+```python
+# Add to src/subprocess/async_executor.py
+from enum import Enum
+import ast
+
+class ExecutionMode(Enum):
+    """From spec lines 69-75"""
+    TOP_LEVEL_AWAIT = "top_level_await"
+    ASYNC_DEF = "async_def"
+    BLOCKING_SYNC = "blocking_sync"
+    SIMPLE_SYNC = "simple_sync"
+    UNKNOWN = "unknown"
+
+class ExecutionRouter:
+    """Routes code to appropriate executor based on analysis."""
+    
+    # From spec lines 96-101
+    BLOCKING_IO_MODULES = {
+        'requests', 'urllib', 'socket', 'subprocess',
+        'sqlite3', 'psycopg2', 'pymongo', 'redis'
+    }
+    
+    def analyze_execution_mode(self, code: str) -> ExecutionMode:
+        """Simplified from spec lines 149-200"""
+        try:
+            tree = ast.parse(code)
+            # Check for top-level await (spec lines 172-175)
+            for node in tree.body:
+                if isinstance(node, ast.Expr):
+                    if self._contains_await(node.value):
+                        return ExecutionMode.TOP_LEVEL_AWAIT
+            return ExecutionMode.SIMPLE_SYNC
+        except SyntaxError:
+            if 'await' in code:
+                return ExecutionMode.TOP_LEVEL_AWAIT
+            return ExecutionMode.UNKNOWN
+```
+
+#### 2.2 Add Basic Promise Abstraction (Pre-Resonate)
+**New File**: `src/subprocess/promise_manager.py`
+**Bridge To**: `docs/async_capability_prompts/current/00_foundation_resonate.md:109-162`
+**Replaces**: Protocol Bridge concept from `docs/async_capability_prompts/archive/obsolete_30_protocol_bridge.md`
+
+```python
+# src/subprocess/promise_manager.py
+class PromiseManager:
+    """Simple promise manager as bridge to Resonate.
+    
+    This is a temporary implementation that will be replaced by
+    Resonate promises as described in foundation_resonate.md:109-162
+    """
+    
+    def __init__(self):
+        self._promises = {}
+        
+    async def create_promise(self, id: str, data: Any) -> asyncio.Future:
+        """Create a promise that can be resolved later.
+        
+        Maps to future Resonate usage (foundation_resonate.md:123-136):
+        promise = self._resonate.promises.create(
+            id=promise_id,
+            timeout=timeout,
+            data=json.dumps(data)
+        )
+        """
+        future = asyncio.create_future()
+        self._promises[id] = {"future": future, "data": data}
+        return future
+        
+    def resolve_promise(self, id: str, result: Any):
+        """Resolve a promise with a result.
+        
+        Maps to future Resonate usage (foundation_resonate.md:153-157):
+        self._resonate.promises.resolve(
+            id=correlation_id,
+            data=json.dumps(result)
+        )
+        """
+        if id in self._promises:
+            promise = self._promises.pop(id)
+            if not promise["future"].done():
+                promise["future"].set_result(result)
+```
+
+#### 2.3 Implement Capability Base Class
+```python
+class Capability:
+    """Base class for capabilities (bridge to future)."""
+    
+    def __init__(self, promise_manager, transport, execution_id):
+        self.promises = promise_manager
+        self.transport = transport
+        self.execution_id = execution_id
+        
+    async def request_response(self, message: Message, timeout: float = 30):
+        """Send message and await response via promise."""
+        promise = await self.promises.create_promise(
+            message.id, 
+            {"type": "capability_request"}
+        )
+        await self.transport.send_message(message)
+        return await asyncio.wait_for(promise, timeout)
+```
+
+### Phase 3: Test Infrastructure Fixes (1 day)
+
+#### 3.1 Fix Test Fixtures
+```python
+# In tests/fixtures/sessions.py:
+@asynccontextmanager
+async def create_session(...):
+    """Create session with proper event loop management."""
+    # Ensure we're in an event loop
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    
+    session = Session(...)
+    # Rest of implementation
+```
+
+#### 3.2 Add Compatibility Layer for Tests
+```python
+# In tests/conftest.py:
+@pytest.fixture
+def async_executor(namespace_manager, transport):
+    """Provide AsyncExecutor for tests."""
+    # For now, returns skeleton that delegates to ThreadedExecutor
+    return AsyncExecutor(namespace_manager, transport, "test-exec")
+```
+
+## Concrete Next Steps (In Order)
+
+### Week 1: Unblock Testing (Phase 0 - Emergency Fixes)
+**Working Branch**: `fix/foundation-phase0-emergency-fixes`
+
+1. **Day 1 Morning**: Add async wrapper to ThreadedExecutor ✅ COMPLETE
+   - File: `src/subprocess/executor.py` (lines 627-674)
+   - Tests Fixed: All 5 executor tests passing
+   - Added timeout protection for mock transports
+   - Commit: `016f42b`
+   
+2. **Day 1 Afternoon**: Fix message field issues ✅ COMPLETE
+   - Files: `tests/unit/test_messages.py` only (worker.py already correct)
+   - Fixed: ResultMessage.execution_time, HeartbeatMessage fields
+   - Result: All 8 message tests passing
+   - Commit: `016f42b`
+   
+3. **Day 2**: Implement merge-only namespace policy ✅ COMPLETE  
+   - Files: `src/subprocess/namespace.py`, `src/subprocess/worker.py`
+   - Spec: `docs/async_capability_prompts/current/24_spec_namespace_management.md:15-29`
+   - Added ENGINE_INTERNALS constant with protected keys
+   - Fixed _setup_namespace() to UPDATE instead of REPLACE
+   - Added update_namespace() method with merge strategies
+   - Created test_namespace_merge.py with 12 comprehensive tests
+   - Commit: `90c2937`
+   
+4. **Day 3**: Create AsyncExecutor skeleton ✅ COMPLETE
+   - New File: `src/subprocess/async_executor.py` (398 lines)
+   - Test File: `tests/unit/test_async_executor.py` (536 lines, 23 tests)
+   - ExecutionMode detection working for all 5 modes
+   - ThreadedExecutor delegation maintains functionality
+   - Event loop management without ownership (no __del__ closing)
+   - Result: 23 new tests passing, 90% AsyncExecutor coverage
+   
+5. **Day 4**: PR Review Feedback Fixes ✅ COMPLETE
+   - **Critical**: Removed dangerous __del__ loop closing from AsyncExecutor
+   - **Critical**: Added explicit lifecycle management (close() and context manager)
+   - **Critical**: Fixed deprecated get_event_loop() → get_running_loop()
+   - **Medium**: Created `src/subprocess/constants.py` for single ENGINE_INTERNALS source
+   - **Medium**: Fixed brittle/flaky tests with proper synchronization
+   - **Low**: Added LRU cache limit, removed unused imports, improved documentation
+   - Result: All reviewer concerns addressed
+
+6. **Day 4 (Extended)**: Additional PR Refinements ✅ COMPLETE
+   - **AST Traversal**: Verified working correctly, added comprehensive edge case tests
+     - File: `tests/unit/test_async_executor.py` lines 251-339
+     - Tests: await in function calls, list comprehensions, dict/set literals, conditionals
+   - **Hash Collisions**: Replaced Python `hash()` with a stable digest for cache keys
+     - File: `src/subprocess/async_executor.py` line 146
+     - Decision: Use `hashlib.md5(code.encode()).hexdigest()` for non-crypto
+       AST cache keys (faster, stable). If needed later, switch specific
+       contexts to SHA-256.
+   - **Result History**: Fixed to only update _ for expression results
+     - File: `src/subprocess/namespace.py` lines 111-118
+     - Only updates _ when key='_', not on all variable assignments
+   - **Event Loop Deprecations**: Fixed remaining get_event_loop() calls
+     - File: `src/subprocess/worker.py` line 572-573
+     - File: `src/protocol/framing.py` lines 60-75
+   - **Cancellation Tests**: Added component-level tests with documented limitations
+     - File: `tests/unit/test_executor.py` lines 223-292
+     - Known limitation: KeyboardInterrupt escapes test isolation
+   - **LRU Cache**: Added eviction test
+     - File: `tests/unit/test_async_executor.py` lines 366-412
+   - **Timeout Configuration**: Replaced hardcoded 0.5s with configurable _drain_timeout
+     - File: `src/subprocess/executor.py` line 675
+   - **Documentation**: Clarified thread safety claims
+     - File: `src/subprocess/async_executor.py` lines 80, 85-87
+
+7. **Day 4+ (Extended)**: Final Reviewer Feedback ✅ COMPLETE
+   - **Event Loop Management**: Removed loop acquisition from __init__ (lines 97-99)
+     - Loop now only obtained when needed in execute()
+     - Allows initialization outside async context
+   - **Event Loop in execute()**: Direct call without try/except (line 341)
+     - Uses `asyncio.get_running_loop()` directly
+     - Lets it raise naturally if not in async context
+   - **SyntaxError Detection**: Improved with PyCF_ALLOW_TOP_LEVEL_AWAIT compile test
+     - File: `src/subprocess/async_executor.py` lines 186-195
+     - Correctly handles `lambda: await foo()` as UNKNOWN
+   - **Test Coverage**: Added test_event_loop_handling.py with 11 tests
+     - Tests nested async contexts, concurrent sessions
+     - Validates all edge cases identified by reviewers
+   - Result: 94/96 unit tests passing (97.9%)
+
+**Goal**: 80% of tests passing ✅ EXCEEDED (97.9% - 94/96 unit tests)
+
+### Week 2: Build Bridge Architecture (Phase 1 & 2)
+**Phase 1 Branch** (Days 5-7): `fix/foundation-phase1-resonate-wrapper`  
+**Phase 2 Branch** (Days 8-10): `fix/foundation-phase2-integration`
+
+#### Critical Insight from Spec Review
+The specs solve the async/await vs yield paradigm through a **wrapper pattern** (refs below):
+- User code uses async/await normally (`22_spec_async_execution.md:252-293`)
+- AsyncExecutor handles async/await with PyCF_ALLOW_TOP_LEVEL_AWAIT (`22_spec_async_execution.md:17-25, 298-339`)
+- Resonate wraps AsyncExecutor in durable functions using yield (`22_spec_async_execution.md:671-734`, `21_spec_resonate_integration.md:133-190`)
+- No code transformation needed - separation of concerns at integration layer (`00_foundation_resonate.md:303-309`)
+
+6. **Day 5: Implement Resonate Wrapper Pattern** (8 hours)
+   - Create durable function wrapper for AsyncExecutor
+   - Based On: `docs/async_capability_prompts/current/22_spec_async_execution.md:671-734`
+   - Pattern:
+     ```python
+     @resonate.register
+     def durable_async_execute(ctx, args):
+         executor = AsyncExecutor(ctx.resonate, namespace_manager, execution_id)
+         result = yield ctx.lfc(executor.execute, {"code": code})
+         return result
+     ```
+   - Test that AsyncExecutor methods work with `ctx.lfc()`
+   
+7. **Day 6: Promise Adapter Layer** (4 hours)
+   - Create `AwaitableResonatePromise` for async/await compatibility
+   - Fix timing issues between Resonate promises and asyncio
+   - Based On: `docs/async_capability_prompts/current/21_spec_resonate_integration.md:319-377`
+   - Key: Make Resonate promises awaitable in async contexts
+   
+8. **Day 7: Migration Adapter Implementation** (4 hours)
+   - Implement `MigrationAdapter` from spec lines 894-922
+   - Based On: `docs/async_capability_prompts/current/21_spec_resonate_integration.md:894-922`
+   - Add intelligent routing based on execution modes:
+     ```python
+     def _should_use_resonate(self, code: str) -> bool:
+         mode = self.analyze_execution_mode(code)
+         return mode in [ExecutionMode.TOP_LEVEL_AWAIT, ExecutionMode.BLOCKING_SYNC]
+     ```
+   
+9. **Day 8: Dependency Injection Refinement** (4 hours)
+   - Fix singleton vs factory patterns for dependencies
+   - Based On: `docs/async_capability_prompts/current/21_spec_resonate_integration.md:243-314`
+   - Critical fix: AsyncExecutor needs factory function, not singleton
+   - Test namespace manager lifecycle with Resonate
+   
+10. **Day 9-10: Integration Testing** (8 hours)
+    - Test checkpoint recovery (`21_spec_resonate_integration.md:754-794`)
+    - Test local vs remote mode consistency
+    - Verify promise resolution in both modes
+    - Test HITL workflows with promises (`21_spec_resonate_integration.md:473-512`)
+    - Performance benchmarks per spec targets (`21_spec_resonate_integration.md:1085-1093`)
+
+**Goal**: 95% tests passing with Resonate integration working in local mode
+
+#### Early Detection Tests (Day 5 - Critical)
+```python
+# Test 1: Verify wrapper pattern works
+def test_resonate_wrapper_pattern():
+    """Based on 22_spec_async_execution.md:671-734"""
+    @resonate.register
+    def wrapped_execute(ctx, args):
+        executor = AsyncExecutor(ctx.resonate, namespace_manager, "test")
+        # This should work - AsyncExecutor's async method called via yield
+        result = yield ctx.lfc(executor.execute, {"code": "x = 1"})
+        return result
+    
+    result = wrapped_execute.run("test-1", {"code": "x = 1"})
+    assert result is not None
+
+# Test 2: Verify no paradigm conflict
+def test_async_await_vs_yield_separation():
+    """Ensure clean separation of concerns"""
+    code = "result = await asyncio.sleep(0, 'test')"
+    
+    # AsyncExecutor handles await internally
+    executor = AsyncExecutor(resonate, namespace_manager, "test")
+    # Resonate wraps with yield externally
+    @resonate.register
+    def durable_exec(ctx, args):
+        result = yield ctx.lfc(executor.execute, {"code": code})
+        return result
+    
+    assert durable_exec.run("test-2", {}) == 'test'
+```
+
+### Week 3: Prepare for Full Specs
+11. Implement basic AsyncExecutor with PyCF_ALLOW_TOP_LEVEL_AWAIT
+12. Add capability message types to protocol
+13. Document migration path to Resonate
+14. Create integration test suite for future architecture
+15. Performance baseline measurements
+
+## Success Criteria
+
+### Immediate Success (Week 1)
+- [x] ThreadedExecutor tests pass with async wrapper ✅ Day 1
+- [x] No Pydantic validation errors ✅ Day 1
+- [x] Namespace never replaced, only merged ✅ Day 2
+- [x] Basic AsyncExecutor skeleton works ✅ Day 3
+- [ ] Event loop errors resolved (Day 3-4)
+
+### Foundation Success (Week 2 - Resonate Integration)
+- [ ] Resonate wrapper pattern working (AsyncExecutor wrapped in durable functions)
+- [ ] Promise adapter bridges yield and await paradigms
+- [ ] Migration adapter routes code intelligently
+- [ ] Dependency injection with proper lifecycles
+- [ ] Local and remote modes behave identically
+- [ ] 95% test pass rate
+
+### Integration Validation Tests
+- [ ] Test 1: AsyncExecutor.execute() works inside Resonate's `ctx.lfc()`
+- [ ] Test 2: Resonate promises are awaitable via adapter
+- [ ] Test 3: Same code produces same results in local and remote modes
+- [ ] Test 4: Checkpoint recovery restores namespace correctly
+- [ ] Test 5: HITL promises resolve correctly across async boundaries
+- [ ] Test 6: Performance meets spec targets (< 1ms local, < 10ms remote)
+
+### Ready for Production (Week 3)
+- [ ] AsyncExecutor handles top-level await with PyCF_ALLOW_TOP_LEVEL_AWAIT
+- [ ] Full Resonate integration with crash recovery
+- [ ] MigrationAdapter allows incremental adoption
+- [ ] Performance benchmarks documented
+- [ ] Architecture documentation reflects wrapper pattern
+
+## Critical Learnings from Full Spec Review
+
+### The Wrapper Pattern Solution
+After reading the full specs, the architecture is elegantly solved:
+1. **No AST transformation needed** - User code remains unchanged
+2. **Separation of concerns** - AsyncExecutor handles async/await, Resonate handles durability
+3. **Clean integration layer** - Resonate wraps AsyncExecutor, not vice versa
+4. **Incremental adoption** - MigrationAdapter allows gradual transition
+
+### Key Integration Points (with Spec References)
+- **Promise Adapter**: Bridge between Resonate promises (yield-based) and asyncio futures (await-based)
+  - Spec: `21_spec_resonate_integration.md:319-418` (PromiseManager and PromiseBasedProtocol)
+  - Pattern: `00_foundation_resonate.md:109-162` (Protocol Bridge with Resonate Promises)
+- **Dependency Injection**: Use factory functions for per-execution instances
+  - Spec: `21_spec_resonate_integration.md:243-314` (Dependency Registration and Access)
+  - Critical: AsyncExecutor must be `singleton=False` (line 264)
+- **Checkpoint Strategy**: Namespace snapshots at each checkpoint for recovery
+  - Spec: `21_spec_resonate_integration.md:569-611` (CheckpointManager)
+  - Example: `21_spec_resonate_integration.md:754-794` (crash_resilient_execution)
+- **Local/Remote Parity**: Same behavior in both modes, different persistence
+  - Local: `21_spec_resonate_integration.md:51-85` (initialize_resonate_local)
+  - Remote: `21_spec_resonate_integration.md:87-126` (initialize_resonate_remote)
+  - Migration: `21_spec_resonate_integration.md:894-922` (MigrationAdapter)
+
+## Risks and Mitigations (Updated)
+
+### Risk 1: Promise Resolution Timing Mismatch
+**Issue**: Resonate promises may not be directly awaitable
+**Mitigation**: Create `AwaitableResonatePromise` adapter class
+**Test Early**: Day 5 - Test promise resolution in both paradigms
+
+### Risk 2: Dependency Lifecycle Issues
+**Issue**: AsyncExecutor needs new instance per execution, not singleton
+**Mitigation**: Use factory functions in dependency registration
+**Test Early**: Day 8 - Verify proper cleanup between executions
+
+### Risk 3: Local vs Remote Behavior Divergence
+**Issue**: Different behavior could break when deploying
+**Mitigation**: Extensive testing in both modes with same test cases
+**Test Early**: Day 9-10 - Run all tests in both local and remote modes
+
+### Risk 4: Performance Overhead in Wrapper Layer
+**Issue**: Multiple layers might introduce latency
+**Mitigation**: Benchmark against spec targets (< 1ms local, < 10ms remote)
+**Test Early**: Day 10 - Performance benchmarks
+
+## Conclusion
+
+The foundation fixes are **essential** before implementing the full specs. We're building a bridge from the current ThreadedExecutor-based system to the future AsyncExecutor + Resonate architecture. By following this plan, we'll have:
+
+1. **Immediate**: Working tests and stable development environment
+2. **Short-term**: Solid foundation that supports both sync and async patterns
+3. **Long-term**: Clear path to implement full specifications
+
+The key is to **fix the basics first**, then **build the bridge**, and finally **implement the vision**.
+
+## PR #11 Triage (Immediate vs Phase 1)
+
+Context: Reviews for PR #11 (branch: `fix/foundation-phase1-resonate-wrapper`) surfaced one high‑severity correctness bug in `AsyncExecutor` plus a few medium/low items. Below is the disposition and how it maps to work now vs Phase 1.
+
+### Fix Now (Day 5 scope)
+- Correct globals binding for top‑level await (direct path): Use the live session namespace dict for `globals` when executing compiled code so any functions created bind their `__globals__` to the real, persistent mapping. Keep a separate `local_ns` to capture top‑level assignments for merge‑only updates.
+  - Code: `src/subprocess/async_executor.py` (replaced `self.namespace.namespace.copy()` with the live mapping and added explanatory comments)
+  - Rationale: Prevents functions from capturing a stale globals mapping and ensures `global` assignments persist across executions.
+- Correct globals binding for AST fallback path: Execute the transformed module with the real session namespace as `globals` so `__async_exec__` binds to the live mapping. Continue merging `locals()` back into the namespace.
+  - Code: `src/subprocess/async_executor.py` (same correction as above; added comments)
+  - Rationale: Aligns both paths with the merge‑only policy and prevents divergence between function `__globals__` and the session namespace.
+- Remove redundant `weakref` import inside method: Use the module‑level import to avoid redeclaration.
+  - Code: `src/subprocess/async_executor.py` (`_track_coroutine`)
+  - Rationale: Minor cleanliness; avoids confusion flagged in review.
+
+Notes
+- Tests: Add targeted tests in Phase 1 to validate that functions defined under both paths retain `__globals__` pointing at the live mapping and that subsequent executions see updated globals. Current suite lacks this coverage (as reviews noted).
+- Spec alignment: Changes are consistent with `24_spec_namespace_management.md` (merge‑only policy) and the PyCF top‑level await behavior noted in the PDF and `22_spec_async_execution.md`.
+
+### Phase 1 (Plan and implement)
+- Dependency Injection factory pattern: Replace error‑prone “get + initialize()” with a factory that yields fully initialized instances per execution context.
+  - Docs: Update `docs/async_capability_prompts/current/21_spec_resonate_integration.md` to show factory registration and access. Ensure AsyncExecutor, NamespaceManager, and transport instances have clear lifecycles.
+  - Code: Introduce DI hooks around the Resonate wrapper; remove any implicit singleton assumptions.
+- Resonate wrapper + promise adapter: Implement the wrapper pattern where Resonate drives durability while AsyncExecutor handles async/await natively. Provide an awaitable adapter over Resonate promises.
+  - Docs: `00_foundation_resonate.md`, `22_spec_async_execution.md`
+  - Code: Wrapper function(s) and `AwaitableResonatePromise` abstraction per spec.
+- Execution mode routing hardening: Finish routing logic and expand blocking‑I/O detection (attribute chains like `time.sleep`, `requests.get`, `socket.recv`). Add tests first to constrain false positives.
+  - Docs: `22_spec_async_execution.md`
+  - Code: Extend AST analysis to resolve `ast.Attribute` and imported name aliases.
+- Top‑level await AST fallback correctness:
+  - Add pre‑exec globals snapshot and apply post‑exec global diffs AFTER locals merge so global writes take precedence (fixes cases like `global g; g=...` being overwritten by wrapper locals).
+  - Adjust AST transform to preserve module‑level semantics for assigned names (emit `ast.Global` where safe) to avoid closure capture of names like `g` inside functions defined in the wrapper.
+  - Tests: New xfails in `tests/unit/test_async_executor_namespace_binding.py` capture these gaps; flip to passing once implemented.
+- Test/CI hygiene:
+  - Relax/mark flaky perf assertion in `tests/unit/test_top_level_await.py` (threshold <100ms). Prefer monotonic timers and a higher ceiling or mark as flaky for CI.
+  - Ensure CI runs unit tests on PRs (e.g., `pytest -m unit`).
+- Config hygiene: Remove or document `.reviewrc.json` “yolo” flag; default to safe behavior and document any local‑only toggles.
+- Compatibility note (AST args): The `ast.arguments` constructor differences for Python <3.8 were flagged in review. Our target is Python 3.11+; add an explicit note in code and docs. If we choose to support older versions later, add version‑guarded construction in Phase 1.
+
+### Key TODOs in Current Implementation
+
+**AsyncExecutor (`src/subprocess/async_executor.py`):**
+- Line 109-110: Make AST cache size configurable via constructor parameter
+- Line 248-252: Extend blocking I/O detection to handle attribute chains (`time.sleep()`, `requests.get()`)
+- Line 261-262: Make blocking I/O detection configurable, add telemetry
+- Line 394-395: Consider pooling ThreadedExecutor instances for performance
+- Line 575-576: Python <3.8 compatibility notes (current target is 3.11+)
+- Namespace binding fixes for AST fallback path (global diffs after locals)
+
+**Resonate Integration:**
+- `src/integration/resonate_functions.py:34-38`: Replace ctx.lfc with promise-first flow
+- `src/integration/resonate_bridge.py:42-46`: Standardize promise ID formats and correlation rules
+- `src/integration/resonate_bridge.py:90-93`: Add Execute/Result/Error correlation
+- `src/integration/resonate_functions.py:73-78`: Handle event loop ownership properly
+
+### Acceptance criteria updates
+- Immediate: Both top‑level await execution paths bind function `__globals__` to the live namespace mapping; namespace updates continue to use merge‑only policy; no namespace replacement anywhere.
+- Phase 1: DI refactor to factory pattern, Resonate wrapper + awaitable promises, expanded routing/detection, improved test/CI hygiene, and config cleanup.
+  - AST fallback: Global diffs applied after locals, no closure capture of would‑be globals for functions defined in fallback; new tests pass without xfail.
+
+## Deferred Refinements (Phase 1 Planning)
+
+- Output drain-timeout suppression policy: Keep current suppression in tests, but in Phase 1 define a configurable policy (flag/env), warn once per execution, and track a small metric so production regressions are visible without destabilizing tests.
+- Blocking I/O detection breadth: Extend `AsyncExecutor._contains_blocking_io` to detect common attribute calls (e.g., `time.sleep`, `requests.get`, `socket.recv`). Add tests first to capture expected patterns and limit false positives.
+- FrameBuffer wakeups: Replace the fixed 10ms sleep in `FrameBuffer.get_frame()` with event/condition wakeups (consistent with `transport.FrameReader`) to reduce latency and CPU wakeups under load.
+
+## Phase 1 Test & CI Summary (2025-09-05)
+
+- Unit tests (uv): 111 passed, 2 skipped, 3 xpassed (expected transitions now passing).
+- New unit tests: TLA timeout override, globals binding under both TLA paths, AST fallback correctness, blocking I/O detection patterns.
+- CI: Added `.github/workflows/unit-tests.yml` to run unit tests on PRs/pushes with Python 3.11.
+
+## Outstanding Work for Phase 2
+
+- Session/Worker integration fixes (source of current integration failures):
+  - Last-expression result delivery for multi-line cells (ensure `ResultMessage.value` carries the last value consistently).
+  - Large output/message handling (chunking and drain ordering) under backpressure.
+  - Checkpoint create/restore pathways and state validation.
+  - Concurrency and lifecycle: robust cancellation, loop binding, and race conditions in session/worker.
+- Event loop lifecycle audit in session/worker: bind asyncio primitives to the correct loop and avoid cross-loop usage.
+- Blocking I/O detection: expose modules/methods via config; add counters/telemetry and structured logs around detections.
+- Performance: add micro-benchmarks and CI perf guardrails for TLA latency and output streaming.
+
+## Phase 2 Sign-off
+
+- Behavior
+  - Durable promise-first with deterministic ids; no asyncio in durable functions
+  - Bridge resolves/rejects with structured payloads; `_pending` cleaned; timeout enrichment present
+  - Single-loop invariant enforced: Session is sole transport reader; tests use interceptors/observer
+  - Worker: output-before-result enforced; Busy guard under concurrency; checkpoint/restore merge-only semantics
+- Tests
+  - Unit: bridge mapping, rejections, timeouts, interceptor robustness, checkpoint bytes/invalidation, drain-timeout error shape
+  - Integration: durable execute ordering (long/CR outputs), Busy guard, checkpoint round-trip
+  - Stress: `_pending` stability under concurrency; Busy acceptance (Phase 3 extended)
+- Docs
+  - Specs (21/22/25) updated for deterministic correlation, rejection semantics, timeouts, drain policy, single-loop testing guidance
+  - Plan updated to mark Phase 2b/2c as Done; Phase 3 items ticketed
+
+## Phase 3 Roadmap (Selected)
+
+- Native async path in AsyncExecutor; coroutine lifecycle/cancellation owner abstraction
+- SessionPool reuse policy, fairness, concurrency semantics; health-check/warmup tuning
+- Remote mode wiring; extended correlation for additional capabilities; retries/backoff; optional `_pending` HWM metric
+- Cancellation hardening for blocking I/O; input EOF/timeout shutdown behavior
+- Performance gates and CI profiling hooks; maxfail tuning on critical paths

--- a/PHASE_3_PR_PLANS.md
+++ b/PHASE_3_PR_PLANS.md
@@ -1,0 +1,318 @@
+  Phase 3 Goals
+
+  - Native AsyncExecutor for TLA/async paths (no ThreadedExecutor for those).
+  - Compile-first TLA using PyCF_ALLOW_TOP_LEVEL_AWAIT; minimal AST wrapper only as resilience.
+  - Coroutine/cancellation lifecycle management and event loop coordination.
+  - Blocking I/O detection breadth + telemetry and config.
+  - Caching for compiled code objects; PEP 657 location mapping for transforms.
+  - Operational refinements: bounded routing concurrency, interceptor budgets, bridge shutdown.
+
+  PR 1 — AsyncExecutor: Native TLA Core (compile-first)
+
+  - Scope
+      - Finalize compile-first TLA execution in src/subprocess/async_executor.py without ThreadedExecutor for TLA paths; keep AST fallback minimal only when compile-first fails.
+      - Preserve namespace semantics: locals-first merge, then global diffs; record expression results via NamespaceManager.record_expression_result.
+  - Key changes
+      - Keep and harden _execute_top_level_await (already present and mostly correct).
+      - Ensure consistent eval/exec handling: try eval+flags first (to preserve expression result), fall back to exec+flags only when required.
+      - Always bind to live namespace mapping; snapshot globals for diffs; never replace mapping.
+      - Use asyncio.timeout(self.tla_timeout), preserve/extend exception notes (execution id, snippet).
+  - Tests
+      - Update/expand tests/unit/test_top_level_await.py to validate compile-first path for assignment and pure expressions; multiple awaits; f-strings; comprehensions; ensure _ history updates.
+      - Validate locals-first then global-diff merge under both eval and exec flows.
+  - Success criteria
+      - All TLA unit tests pass; expression results recorded; no global mapping replacement; AST fallback used only when compile-first SyntaxError occurs.
+  - Changelog
+      - After PR acceptance, update `docs/PHASE_3_CHANGELOG.md` with a concise summary of behavior changes, tests, and any notable decisions.
+
+  Note: Maintain the Phase 3 changelog after each PR is successfully validated and accepted.
+
+  PR 2 — AsyncExecutor: Native Simple Sync + Async Def (no delegation)
+
+  - Scope
+      - Execute simple sync and async-def defining code natively in AsyncExecutor (no delegation to ThreadedExecutor), reserving delegation for true blocking I/O.
+  - Key changes
+      - Add _execute_simple_sync and “async-def defining” execution path using compile(..., mode='exec'); preserve namespace merge semantics.
+      - Keep “blocking” delegation as-is for now (still uses ThreadedExecutor).
+  - Tests
+      - Adjust tests/unit/test_async_executor.py to remove assertions that simple sync code delegates to ThreadedExecutor.
+      - Add tests that native exec preserves namespace identity and results for mixed sequences (sync → async → sync).
+  - Success criteria
+      - No delegation on simple sync and async-def-defining code paths; namespace object identity remains stable across runs.
+
+  PR 3 — AsyncExecutor: AST Fallback Wrapper, Minimal and PEP 657-aligned
+
+  - Scope
+      - Limit transforms to a minimal async wrapper function only; remove broad “def→async def” conversions by default; keep zero-arg lambda→async helper behind a disabled-by-default flag.
+  - Key changes
+      - Strip or flag off the current transform that rewrites def→async def when _contains_await (default OFF).
+      - Keep wrapper shape that preserves original order; inject return locals() for statements; use copy_location and fix_missing_locations; do not reorder user statements.
+  - Tests
+      - Expand AST fallback tests to confirm minimal wrapper behavior; ensure location info in tracebacks maps correctly (PEP 657 expectations).
+  - Success criteria
+      - AST fallback is minimal and semantics-preserving by default; location mapping and error spans are correct.
+
+  PR 4 — Coroutine Lifecycle + Cancellation Management
+
+  - Scope
+      - Introduce an internal CoroutineManager (lightweight) for AsyncExecutor to track the top-level coroutine and provide a cooperative cancel API; ensure cleanup is reliable.
+  - Key changes
+      - Track the coroutine returned by eval/exec; close on completion/error.
+      - Provide AsyncExecutor.cancel_current() which cancels the pending top-level coroutine/task, recording metrics; do not try to cancel user-launched background tasks.
+      - Add basic “cancelled” telemetry counters; structure exception add_notes for cancellation context.
+  - Tests
+      - New unit tests: long-running await cancels cooperatively; cleanup still occurs on error and cancel; no coroutine leaks.
+  - Success criteria
+      - Cancelling an in-flight TLA run interrupts promptly; cleanup_coroutines() returns 0 afterward; tests validate cooperative cancel path.
+
+  PR 5 — Blocking I/O Detection Refinements + Telemetry
+
+  - Scope
+      - Harden detection breadth and reduce false positives: attribute chain resolution, alias tracking, overshadowing; expose config knobs and counters.
+  - Key changes
+      - Build on current _contains_blocking_io (already has alias and attribute chain resolution).
+      - Add overshadowing checks (user requests = object() shouldn’t signal blocking); per-module method lists remain configurable; add structured counters and optional warnings.
+  - Tests
+      - tests/unit/test_async_executor_detection_breadth.py: add overshadowing tests; alias from imported names; deep attribute chains like socket.socket().recv.
+      - Validate counters (detected_blocking_import/call; missed_attribute_chain ≤ expected).
+  - Success criteria
+      - Detection covers common patterns with fewer false positives; config toggles work; telemetry counters increment as expected.
+
+  PR 6 — Code Object LRU Cache (compile cache)
+
+  - Scope
+      - Add a compiled-code LRU cache keyed by (source, mode, flags) to skip recompile; keep AST cache only for transform cases.
+  - Key changes
+      - New cache in AsyncExecutor (small default size, configurable; reuse existing env override pattern used by AST cache).
+      - Do not cache in error cases; differentiate eval vs exec and flags; clear strategy is LRU.
+  - Tests
+      - New unit tests verifying cache reuse, keying correctness, and eviction behavior.
+  - Success criteria
+      - Repeated code paths get faster; cache key correctness validated.
+
+  PR 7 — Optional Symtable-backed Hoisting (feature flag, default OFF)
+
+  - Scope
+      - Add a guarded feature to hoist safe, unconditional top-level imports/defs ahead in wrapper compilation without reordering relative import/def order; default OFF.
+  - Key changes
+      - Use symtable to identify safe bindings; maintain original relative order; treat TypeAlias as assignment-like; do nothing unless flag is enabled.
+  - Tests
+      - Corpus tests: simple imports/defs hoist successfully; conditional or shadowed defs are not hoisted; semantics preserved with/without flag.
+  - Success criteria
+      - Feature behind flag; semantics preserved; tests green; documentation clarifies OFF by default.
+
+  PR 8 — Event Loop Coordinator (small, guardrails and docs)
+
+  - Scope
+      - Provide a tiny EventLoopCoordinator for AsyncExecutor that standardizes “you must call from a running loop” errors and queues any optional executor internal coroutines; durable functions still must not manage loops.
+  - Key changes
+      - Add a helper to detect running loop and raise clear guidance; optionally queue internal non-critical coros (diagnostics) for later flush in tests only.
+  - Tests
+      - tests/unit/test_event_loop_handling.py updated for clearer error messages and nested async contexts.
+  - Success criteria
+      - Clear, deterministic errors when called out-of-loop; no loop creation performed by AsyncExecutor.
+
+  PR 9 — Operational Refinements: Session Routing Concurrency + Interceptor Budgets
+
+  - Scope
+      - Bound routing task concurrency and add interceptor timing budgets; structured warnings on overruns; maintain single-loop invariant.
+  - Key changes
+      - In src/session/manager.py: add optional max_routing_concurrency (Semaphore) around _route_message task creation; collect basic durations for interceptors and log slow-call warnings (configurable budget, e.g., 10ms).
+  - Tests
+      - Stress test: flood of outputs doesn’t starve routing; assert that routing doesn’t leak tasks; interceptors exceeding budget raise warnings but do not break routing.
+  - Success criteria
+      - No regressions; routing remains stable under burst; slow interceptors visible via logs.
+
+  PR 10 — Bridge Lifecycle: close()/cancel_all(), HWM metric exposure
+
+  - Scope
+      - Add lifecycle to ResonateProtocolBridge for cancelling timeouts and clearing pending; expose HWM via getter.
+  - Key changes
+      - Implement close()/cancel_all() to cancel timeout tasks and reject pending with a canned shutdown error; expose pending_high_water_mark().
+      - Wire DI shutdown path to call bridge.close() in resonate_init.
+  - Tests
+      - Unit tests to verify pending cleanup and rejection; race tests rewritten to event-based synchronization (no sleeps).
+  - Success criteria
+      - No pending correlations left after close(); race tests deterministic; HWM getter returns expected values.
+
+  PR 11 — Documentation + Spec Alignment + Config Knobs
+
+  - Scope
+      - Update docs under docs/async_capability_prompts/current/ with final decisions:
+      - Compile-first policy (3.11–3.13), minimal AST fallback, transforms OFF by default.
+      - Blocking I/O detection config; caching; loop ownership; interceptor budgets.
+  - Update API reference with final AsyncExecutor constructor knobs and behavior.
+  - Key changes
+      - Refresh 10/20/22/24/25 docs to reflect implemented behaviors; mark previous TODOs addressed.
+  - Tests
+      - None (docs only); ensure lint/type/docs checks pass.
+  - Success criteria
+      - Docs clearly match implementation; reviewers sign off on spec parity.
+
+  PR 12 — Benchmarks + CI Guardrails (optional stretch within Phase 3)
+
+  - Scope
+      - Add light microbenchmarks as tests or separate script to validate perf targets and cache effects; put simple thresholds in comments (no flaky asserts).
+  - Key changes
+      - Benchmark TLA on no-op and small awaits; repeated compile caching; routing throughput under bursts.
+  - Tests
+      - Non-flaky microbenchmarks behind a -m perf marker (opt-in).
+  - Success criteria
+      - Baseline numbers captured; later phases can track regressions.
+
+  Cross-Cutting Concerns
+
+  - Single-loop invariant: keep session as the only transport reader; interceptors remain non-blocking; bridge never reads.
+  - Namespace policy: never replace dict; locals-first then global diffs; preserve ENGINE_INTERNALS.
+  - Error semantics: use exception notes with execution id/snippets; AST wrapper preserves PEP 657 spans.
+  - Config surfaces: timeouts, cache sizes, blocking detection modules/methods, warning toggles, interceptor budgets, routing concurrency limit.
+
+  Workloads & Testing Summary
+
+  - Unit
+      - AsyncExecutor TLA (eval/exec), AST fallback, globals binding, result history, caching keys, detection breadth/false positives, cancellation/cleanup.
+      - Bridge correlation + lifecycle, pending/timeouts, race determinism.
+      - Session routing semaphore + interceptor budget warnings.
+  - Integration
+      - End-to-end worker/session remains ThreadedExecutor-based; ensure Phase 2b/2c invariants hold (output-before-result, Busy guard, checkpoint/restore logic).
+      - Do not introduce competing readers; continue using interceptors in integration tests.
+  - Performance
+      - Validate cache win in unit-level measures (short loops); optional perf marker in CI.
+
+  Justifications
+
+  - Narrow, compile-first approach avoids semantic drift and keeps error locations correct; matches Python 3.11–3.13 capabilities.
+  - Removing (or disabling) broad def→async transforms reduces risk; fallback wrapper suffices for resilience.
+  - Native simple/async-def execution avoids ThreadedExecutor overhead; blocking I/O still delegates safely.
+  - Coroutine lifecycle + cancel address async-specific concerns that ThreadedExecutor’s sync cancellation cannot.
+  - Operational caps (routing concurrency; interceptor budgets) improve resilience under load without architectural churn.
+
+  Dependencies & Sequencing
+
+  - PRs 1–3 must go first (core execution semantics).
+  - PRs 4–6 can proceed after 1–3; 7 (hoisting) is optional and behind a flag.
+  - PRs 8–10 are operational and can be parallelized after 2; merge after focused review.
+  - PR 11 can land at the end; PR 12 is optional.
+
+  Success Criteria (Phase 3 overall)
+
+  - AsyncExecutor runs TLA/async-def and simple sync natively; ThreadedExecutor only for blocking sync.
+  - Minimal AST fallback only; transforms OFF by default; correct error spans.
+  - Cancellation works for async; no coroutine leaks.
+  - Blocking I/O detection broadened with fewer false positives; telemetry present.
+  - Code-object caching speeds repeated runs; cache keys distinguish (source, mode, flags).
+  - Session routing remains stable; interceptor slow calls visible; bridge lifecycle implemented.
+
+  Reading Guide Per PR (Phase 3)
+
+  PR 1 — AsyncExecutor: Native TLA Core (compile-first)
+  - Read
+      - FOUNDATION_FIX_PLAN.md (Phase 3: Full AsyncExecutor Implementation; Research‑Informed Updates)
+      - docs/async_capability_prompts/current/22_spec_async_execution.md (TLA compile matrix; CO_COROUTINE checks; eval vs exec; PEP 657)
+      - docs/async_capability_prompts/current/24_spec_namespace_management.md (merge‑only; locals‑first then global diffs; history)
+      - docs/async_capability_prompts/current/20_spec_architecture.md (compile‑first + minimal transform policy; single‑loop invariant)
+      - docs/async_capability_prompts/current/25_spec_api_reference.md (AsyncExecutor API/config notes)
+      - Source: src/subprocess/async_executor.py, src/subprocess/namespace.py
+      - Tests: tests/unit/test_top_level_await.py; tests/unit/test_async_executor_namespace_binding.py; tests/unit/test_event_loop_handling.py
+  - Glean
+      - Prefer compile‑first with flags; await coroutine result; record expression results; merge locals then global diffs; keep PEP 657 spans; enrich exceptions with notes
+
+  PR 2 — AsyncExecutor: Native Simple Sync + Async Def
+  - Read
+      - FOUNDATION_FIX_PLAN.md (Phase 3 native async path; delegation reserved for blocking)
+      - docs/async_capability_prompts/current/22_spec_async_execution.md (Execution Mode Detection; Core Execution Methods)
+      - docs/async_capability_prompts/current/10_prompt_async_executor.md (design + routing)
+      - docs/async_capability_prompts/current/24_spec_namespace_management.md (merge‑only semantics)
+      - Source: src/subprocess/async_executor.py; reference src/subprocess/executor.py
+      - Tests: tests/unit/test_async_executor.py; tests/unit/test_namespace_merge.py
+  - Glean
+      - Run simple/defining code natively; preserve namespace identity; keep delegation strictly for blocking sync
+
+  PR 3 — Async Fallback Wrapper (minimal)
+  - Read
+      - FOUNDATION_FIX_PLAN.md (no mass transforms; wrapper only; PEP 657)
+      - docs/async_capability_prompts/current/22_spec_async_execution.md (AST Fallback; Location Mapping)
+      - docs/async_capability_prompts/current/24_spec_namespace_management.md (locals‑first then global diffs on fallback)
+      - Source: src/subprocess/async_executor.py (transform site)
+      - Tests: tests/unit/test_top_level_await.py; tests/unit/test_async_executor.py (AST)
+  - Glean
+      - Keep wrapper minimal; don’t reorder; preserve error spans; avoid broad def→async unless flagged
+
+  PR 4 — Coroutine Lifecycle + Cancellation
+  - Read
+      - FOUNDATION_FIX_PLAN.md (CoroutineManager; ExecutionCancellation; metrics)
+      - docs/async_capability_prompts/current/22_spec_async_execution.md (Event loop coord; TaskGroup; timeout)
+      - Source: src/subprocess/async_executor.py; src/session/manager.py (cancel/interrupt); src/subprocess/worker.py (cancel interplay)
+      - Tests: tests/features/test_cancellation.py; tests/features/test_event_driven.py; tests/unit/test_executor.py (cancellation components)
+  - Glean
+      - Track top-level coroutine; cancel cooperatively; cleanup reliably; simple counters for visibility
+
+  PR 5 — Blocking I/O Detection + Telemetry
+  - Read
+      - FOUNDATION_FIX_PLAN.md (detection breadth; telemetry; config)
+      - docs/async_capability_prompts/current/22_spec_async_execution.md (blocking indicators; attribute chains)
+      - Source: src/subprocess/async_executor.py (_contains_blocking_io; policy)
+      - Tests: tests/unit/test_async_executor_detection_breadth.py; tests/unit/test_async_executor.py (telemetry)
+  - Glean
+      - Resolve attribute bases with alias mapping; guard overshadowing; expose config; optional warnings; counters for imports/calls
+
+  PR 6 — Code Object LRU Cache
+  - Read
+      - FOUNDATION_FIX_PLAN.md (code‑object caching keyed by source+mode+flags)
+      - docs/async_capability_prompts/current/22_spec_async_execution.md (Caching Strategy)
+      - Source: src/subprocess/async_executor.py
+      - Tests: tests/unit/test_async_executor_ast_cache_config.py (pattern); add code‑object cache tests
+  - Glean
+      - LRU keyed by (source, mode, flags); avoid caching failures; keep AST cache only for transformed trees
+
+  PR 7 — Optional Symtable Hoisting (flagged)
+  - Read
+      - FOUNDATION_FIX_PLAN.md (symbol‑aware hoisting — optional)
+      - docs/async_capability_prompts/current/22_spec_async_execution.md (AST coverage + hoisting cautions)
+      - Source: src/subprocess/async_executor.py
+      - Tests: add new ON/OFF hoisting tests
+  - Glean
+      - Hoist safe, unconditional defs/imports only; preserve order; keep OFF by default
+
+  PR 8 — Event Loop Coordinator
+  - Read
+      - FOUNDATION_FIX_PLAN.md (EventLoopCoordinator goals)
+      - docs/async_capability_prompts/current/22_spec_async_execution.md (Event Loop Considerations; asyncio.timeout usage)
+      - Source: src/subprocess/async_executor.py
+      - Tests: tests/unit/test_event_loop_handling.py
+  - Glean
+      - Standardize error surfaces for missing loop; never create loops; optionally queue internal diagnostics in tests only
+
+  PR 9 — Session Routing Concurrency + Interceptor Budgets
+  - Read
+      - FOUNDATION_FIX_PLAN.md (Operational refinements)
+      - docs/async_capability_prompts/current/20_spec_architecture.md (single‑loop; interceptors)
+      - Source: src/session/manager.py (_receive_loop; _route_message)
+      - Tests: add unit/integration for semaphore + slow interceptor warnings
+  - Glean
+      - Bound routing task fan‑out; measure interceptor durations; warn on overruns; no routing regressions
+
+  PR 10 — Bridge Lifecycle (close/cancel_all; HWM)
+  - Read
+      - FOUNDATION_FIX_PLAN.md (bridge lifecycle; DI shutdown; race determinsm)
+      - docs/async_capability_prompts/current/25_spec_api_reference.md (bridge correlation + timeout)
+      - Source: src/integration/resonate_bridge.py; src/integration/resonate_init.py
+      - Tests: tests/unit/test_resonate_protocol_bridge.py; tests/unit/test_resonate_protocol_bridge_race.py
+  - Glean
+      - Cancel timeouts; reject pending on close; expose pending HWM; keep single‑loop ownership
+
+  PR 11 — Docs + Spec Alignment
+  - Read
+      - FOUNDATION_FIX_PLAN.md (Phase 3 + Architecture Alignment)
+      - docs/async_capability_prompts/current/{10,20,22,24,25}_*.md
+  - Glean
+      - Document compile‑first policy; fallback limits; detection config; caching; loop ownership; routing/budgets; API defaults
+
+  PR 12 — Benchmarks + CI Guardrails (optional)
+  - Read
+      - FOUNDATION_FIX_PLAN.md (Performance & observability)
+      - docs/async_capability_prompts/current/20_spec_architecture.md (performance targets)
+      - Source: src/subprocess/async_executor.py; src/session/manager.py
+      - Tests/Benches: add opt‑in perf markers (-m perf)
+  - Glean
+      - Baseline TLA latency and caching wins; no flaky thresholds

--- a/docs/async_capability_prompts/current/00_foundation_resonate.md
+++ b/docs/async_capability_prompts/current/00_foundation_resonate.md
@@ -1,0 +1,353 @@
+# Resonate Foundation - Durability and Orchestration Layer
+
+## Your Mission
+
+You are tasked with integrating Resonate SDK as the foundational durability and orchestration layer for PyREPL3. Resonate will provide automatic recovery, distributed execution, and promise-based communication while maintaining our zero-dependency philosophy for local development.
+
+## Why Resonate?
+
+### Problems It Solves
+1. **Durability**: Executions can recover from crashes without custom checkpointing
+2. **Promise Management**: Replace our Protocol Bridge futures with durable promises
+3. **Dependency Injection**: Clean capability management without global state
+4. **HITL Workflows**: Native support for human-in-the-loop via promise resolution
+5. **Distribution**: Scale from single-worker to multi-worker without code changes
+
+### Architectural Fit
+```
+┌─────────────────────────────────────────┐
+│            PyREPL3 Worker               │
+├─────────────────────────────────────────┤
+│         Resonate (Durability Layer)     │
+│  ┌─────────────┬──────────┬──────────┐ │
+│  │AsyncExecutor│ Protocol  │Capability│ │
+│  │  (Durable)  │  Bridge   │  System  │ │
+│  │             │(Promises) │  (Deps)  │ │
+│  └─────────────┴──────────┴──────────┘ │
+├─────────────────────────────────────────┤
+│          Transport Layer                │
+└─────────────────────────────────────────┘
+```
+
+## Integration Strategy
+
+### Phase 1: Local Mode (Development)
+```python
+from resonate import Resonate
+
+# Zero external dependencies - uses in-memory storage
+resonate = Resonate.local()
+
+# Everything works except crash recovery
+@resonate.register
+def execute_code(ctx, args):
+    # Full functionality, no server required
+    pass
+```
+
+### Phase 2: Remote Mode (Production)
+```python
+# Same code, just different initialization
+resonate = Resonate.remote(host="resonate-server")
+
+# Now supports:
+# - Crash recovery
+# - Multi-worker execution
+# - Distributed promises
+# - Cross-process coordination
+```
+
+## Core Components Integration
+
+### Promise‑First Durable Flow (Required)
+
+Durable functions SHOULD create a promise, send a protocol request via the bridge, then yield the promise. Do not spin up event loops or pass async callables to `ctx.lfc`.
+
+### 1. AsyncExecutor with Resonate
+
+**Current Challenge**: Need durability for long-running executions with top-level await
+
+**Resonate Solution (Promise‑First)**:
+```python
+@resonate.register
+def durable_execute(ctx, args):
+    code = args['code']
+    execution_id = args['execution_id']
+    bridge = ctx.get_dependency('protocol_bridge')
+
+    # Create durable promise
+    promise = yield ctx.promise(id=f"exec:{execution_id}")
+
+    # Send execute request; bridge resolves the promise on response
+    yield bridge.send_request('execute', execution_id, ExecuteMessage(...), timeout=30.0)
+
+    # Wait for durable result
+    result = yield promise
+    return result
+
+# Usage with automatic recovery
+result = durable_execute.run(execution_id, {
+    'code': code,
+    'namespace': current_namespace
+})
+```
+
+### 2. Protocol Bridge with Resonate Promises
+
+**Current Challenge**: Managing request/response correlation with futures
+
+**Resonate Solution**:
+```python
+class ResonateProtocolBridge:
+    """Protocol Bridge using Resonate's durable promises."""
+    
+    def __init__(self, resonate: Resonate, transport: MessageTransport):
+        self._resonate = resonate
+        self._transport = transport
+        
+    async def send_request(
+        self,
+        capability_id: str,
+        execution_id: str,
+        message: Message,
+        timeout: Optional[float] = None
+    ) -> Promise:
+        """Send request and return durable promise."""
+        
+        # Create durable promise that survives crashes
+        promise_id = f"{execution_id}:{capability_id}:{message.id}"
+        
+        promise = self._resonate.promises.create(
+            id=promise_id,
+            timeout=int((time.time() + timeout) * 1000) if timeout else None,
+            data=json.dumps({
+                'capability_id': capability_id,
+                'execution_id': execution_id,
+                'message_type': message.type
+            })
+        )
+        
+        # Send the protocol message
+        await self._transport.send_message(message)
+        
+        # Return promise that can be awaited
+        return promise
+    
+    async def route_response(self, message: Message) -> bool:
+        """Route response by resolving promise."""
+        
+        correlation_id = self._extract_correlation_id(message)
+        if not correlation_id:
+            return False
+        
+        try:
+            # Resolve the durable promise
+            self._resonate.promises.resolve(
+                id=correlation_id,
+                data=json.dumps(message.to_dict())
+            )
+            return True
+        except PromiseNotFoundError:
+            # No waiting promise
+            return False
+```
+
+### 3. Capability System with Dependencies
+
+**Current Challenge**: Managing capability lifecycle and injection
+
+**Resonate Solution**:
+```python
+# Register capabilities as Resonate dependencies
+def initialize_capabilities(resonate: Resonate, transport: MessageTransport):
+    """Register all capabilities as dependencies."""
+    
+    # Core I/O capabilities
+    resonate.set_dependency("input", InputCapability(transport))
+    resonate.set_dependency("print", PrintCapability(transport))
+    resonate.set_dependency("display", DisplayCapability(transport))
+    
+    # File capabilities
+    resonate.set_dependency("read_file", FileReadCapability(transport))
+    resonate.set_dependency("write_file", FileWriteCapability(transport))
+    
+    # Network capabilities (if allowed by security policy)
+    if security_policy.allows("network"):
+        resonate.set_dependency("fetch", FetchCapability(transport))
+        resonate.set_dependency("websocket", WebSocketCapability(transport))
+
+# Access in durable functions
+@resonate.register
+def execute_with_input(ctx, args):
+    """Execute code that needs user input."""
+    
+    # Get capability from dependency injection
+    input_cap = ctx.get_dependency("input")
+    
+    # Create HITL promise for user input
+    promise = yield ctx.promise(
+        id=f"input:{args['execution_id']}:{uuid.uuid4()}",
+        data={"prompt": args['prompt'], "type": "user_input"}
+    )
+    
+    # Wait for human to resolve the promise
+    user_input = yield promise
+    
+    return user_input['data']
+```
+
+### 4. HITL (Human-In-The-Loop) Workflows (Promise‑Driven)
+
+**Current Challenge**: Blocking for user input without freezing execution
+
+**Resonate Solution**:
+```python
+class InputCapability:
+    """Input capability using Resonate promises for HITL."""
+    
+    def __init__(self, resonate: Resonate, bridge: Any):
+        self._resonate = resonate
+        self._bridge = bridge
+    
+    async def request_input(self, prompt: str, execution_id: str) -> str:
+        """Request input from user via HITL promise."""
+        
+        # Send via protocol bridge and await durable promise
+        msg = InputMessage(
+            id=str(uuid.uuid4()),
+            prompt=prompt,
+            execution_id=execution_id
+        )
+        promise = await self._bridge.send_request("input", execution_id, msg, timeout=300.0)
+        result = await promise.result()
+        return json.loads(result).get('input', '')
+```
+
+## Configuration and Initialization
+
+### Development Setup (Local)
+```python
+# src/subprocess/resonate_init.py
+
+def initialize_resonate_local(session: Session, resonate: Optional[Resonate] = None) -> Resonate:
+    """Initialize Resonate in local mode for development."""
+    
+    resonate = resonate or Resonate.local()
+    
+    # Register all durable functions
+    register_executor_functions(resonate)
+    
+    # Set up dependencies (bridge uses session; session is single reader)
+    bridge = ResonateProtocolBridge(resonate, session)
+    resonate.set_dependency("protocol_bridge", bridge)
+    resonate.set_dependency("input_capability", lambda: InputCapability(resonate, bridge))
+    
+    return resonate
+```
+
+### Production Setup (Remote — Planned)
+```python
+def initialize_resonate_remote(
+    host: str = "http://localhost:8001",
+    worker_group: str = "pyrepl3-workers"
+) -> Resonate:
+    """Planned: remote initializer; not implemented in this codebase."""
+    ...
+```
+
+## Migration Path
+
+### Step 1: Wrap Existing Code
+Prefer a temporary sync facade that posts work to the executor’s loop via `run_coroutine_threadsafe` if a sync `lfc` path is unavoidable. Do NOT create new event loops inside durable functions.
+
+### Step 2: Gradually Adopt Features
+```python
+# Add durability to specific operations
+@resonate.register  
+def durable_file_operation(ctx, args):
+    file_cap = ctx.get_dependency("file")
+    
+    # This operation can now recover from crashes
+    content = yield ctx.lfc(file_cap.read, {'path': args['path']})
+    processed = yield ctx.lfc(process_content, {'content': content})
+    yield ctx.lfc(file_cap.write, {'path': args['output'], 'data': processed})
+    
+    return "Processing complete"
+```
+
+### Step 3: Full Integration
+- Replace Protocol Bridge futures with Resonate promises
+- Use Resonate dependencies for all capabilities
+- Leverage HITL for all user interactions
+- Enable distributed execution across workers
+
+## Anti‑Patterns (Do Not Do)
+
+- Spinning up event loops inside durable functions (`asyncio.new_event_loop()`, `run_until_complete`)
+- Passing `async def` callables to `ctx.lfc` (use `ctx.lfi` or promise‑first)
+- Rebinding transport/executor to multiple loops
+
+## Benefits Summary
+
+1. **Incremental Adoption**: Start with `Resonate.local()`, no server required
+2. **Durability**: Automatic recovery from crashes
+3. **Simplified Code**: Remove custom promise tracking and correlation
+4. **HITL Native**: Built-in support for human-in-the-loop workflows
+5. **Distribution Ready**: Scale to multiple workers when needed
+6. **Observability**: Built-in metrics and tracing
+
+## Testing Strategy
+
+### Local Mode Tests
+```python
+def test_local_execution():
+    """Test that local mode works without server."""
+    resonate = Resonate.local()
+    
+    @resonate.register
+    def test_func(ctx, args):
+        return args['value'] * 2
+    
+    result = test_func.run("test-1", {'value': 21})
+    assert result == 42
+```
+
+### Recovery Tests
+```python
+def test_crash_recovery():
+    """Test that execution recovers from crash."""
+    resonate = Resonate.remote()
+    
+    @resonate.register
+    def crashable_func(ctx, args):
+        if args.get('crash'):
+            raise Exception("Simulated crash")
+        return "Success"
+    
+    # Start execution that will crash
+    promise = crashable_func.rpc("test-2", {'crash': True})
+    
+    # Simulate recovery by retrying without crash flag
+    # Resonate will resume from last checkpoint
+    result = crashable_func.run("test-2", {'crash': False})
+    assert result == "Success"
+```
+
+## Non-Negotiables
+
+1. **Local Mode First**: Must work without any server for development
+2. **Zero Breaking Changes**: Existing code continues to work
+3. **Gradual Migration**: Can adopt Resonate incrementally
+4. **Performance**: No significant overhead in local mode
+5. **Simplicity**: Abstractions should reduce complexity, not add it
+
+## Success Criteria
+
+- [ ] AsyncExecutor wrapped in durable function
+- [ ] Protocol Bridge uses Resonate promises
+- [ ] Capabilities registered as dependencies
+- [ ] HITL workflows use promise resolution
+- [ ] Local mode works without server
+- [ ] Remote mode enables crash recovery
+- [ ] Tests pass in both local and remote modes
+- [ ] Performance overhead < 5% in local mode

--- a/docs/async_capability_prompts/current/10_prompt_async_executor.md
+++ b/docs/async_capability_prompts/current/10_prompt_async_executor.md
@@ -1,0 +1,477 @@
+# Async Executor Implementation Planning Prompt (REFINED with Resonate)
+
+## Your Mission
+
+You are tasked with implementing an async-first execution model that supports top-level await WITHOUT using IPython as a dependency. Build a custom async executor using the compile flag `PyCF_ALLOW_TOP_LEVEL_AWAIT = 0x2000` from Python's ast module, wrapped in Resonate durable functions for automatic recovery and distributed execution support.
+
+## Context Gathering Requirements
+
+Before implementing, you MUST understand:
+
+### 1. Problem History (NEW INSIGHT)
+- **IPython Integration Attempt**: Failed due to `_oh` KeyError when replacing namespace
+- **Key Lesson**: Never replace user_ns entirely - must preserve execution engine internals
+- **Invariant**: Namespace must be under our control without breaking display hooks
+
+### 2. Critical Technical Discovery
+- **The Magic Flag**: `PyCF_ALLOW_TOP_LEVEL_AWAIT = 0x2000` enables top-level await in compile(); prefer a compile-first strategy and only use an AST wrapper as a resilience fallback when direct compilation is unsuitable
+- **How It Works**: Add to compile flags: `compile(code, '<session>', 'exec', flags=base_flags | 0x2000)`; evaluate the code object to a coroutine and await it when `CO_COROUTINE` is set
+- **Edge Case**: Rarely, a minimal AST wrapper is needed when the compile-first path fails for reasons outside ordinary top-level async constructs; keep wrapper minimal and preserve ordering/locations
+
+### 3. Architecture Recognition
+- **ThreadedExecutor**: Works perfectly for sync/blocking code - DO NOT break it; route only blocking paths to threads, keep native async paths for TLA/async defs
+- **Protocol Transport**: Already async-aware but needs careful event loop management
+- **Namespace Manager**: Thread-safe but needs async context awareness
+
+### 4. Constraints That Cannot Be Violated
+- **No IPython Dependency**: We build our own to maintain control
+- **Compile-First**: Use `PyCF_ALLOW_TOP_LEVEL_AWAIT` with `exec`/`eval`; evaluate to coroutine and await it; fallback wrapper only when necessary
+- **Cancellation Support**: Must support sys.settrace for sync, but async is harder
+- **Protocol Order**: Message ordering must be preserved despite async execution
+- **Memory Safety**: No coroutine leaks in namespace
+
+## Planning Methodology
+
+### Phase 1: Analysis (30% effort - REDUCED from 40%)
+<context_gathering>
+Goal: Extract IPython's top-level await patterns WITHOUT inheriting its problems
+Stop when: You understand compile flag usage and AST transformation needs
+Depth: Focus on compile() mechanics, NOT IPython internals
+</context_gathering>
+
+Key Investigation Points:
+1. How to detect if code needs `PyCF_ALLOW_TOP_LEVEL_AWAIT`
+2. When AST transformation is required vs direct compilation  
+3. How to handle coroutine results vs regular returns
+4. Event loop lifecycle in subprocess context
+
+### Phase 2: Solution Design (50% effort - INCREASED focus on implementation)
+
+**Core AsyncExecutor Design (REFINED with Resonate):**
+
+```python
+# src/subprocess/async_executor.py
+import ast
+import asyncio
+import sys
+import types
+from typing import Any, Dict, Optional
+from resonate_sdk import Resonate
+
+class AsyncExecutor:
+    """Custom async executor with top-level await support and Resonate durability."""
+    
+    # Critical discovery from investigation
+    PyCF_ALLOW_TOP_LEVEL_AWAIT = 0x2000
+    
+    def __init__(
+        self, 
+        resonate: Resonate,
+        namespace_manager: NamespaceManager,
+        execution_id: str
+    ):
+        self.resonate = resonate
+        self.namespace = namespace_manager
+        self.execution_id = execution_id
+        # DO NOT create new event loop - use existing
+        self.loop = asyncio.get_event_loop()
+        
+    async def execute(self, code: str) -> Any:
+        """Execute with top-level await support."""
+        
+        # Detect execution mode
+        mode = self._analyze_execution_mode(code)
+        
+        if mode == 'top_level_await':
+            return await self._execute_with_top_level_await(code)
+        elif mode == 'async_def':
+            return await self._execute_async_definitions(code)
+        elif mode == 'blocking_sync':
+            # Delegate to ThreadedExecutor for blocking I/O
+            return await self._execute_in_thread(code)
+        else:
+            # Simple sync code
+            return self._execute_sync(code)
+    
+    def _analyze_execution_mode(self, code: str) -> str:
+        """Determine execution mode - REFINED logic."""
+        try:
+            # Try to parse normally first
+            tree = ast.parse(code)
+            
+            # Check for await at module level (not inside function)
+            for node in tree.body:
+                if isinstance(node, ast.Expr):
+                    if self._contains_await(node.value):
+                        return 'top_level_await'
+            
+            # Check for async function definitions
+            if any(isinstance(n, ast.AsyncFunctionDef) for n in ast.walk(tree)):
+                return 'async_def'
+            
+            # Check for blocking I/O patterns
+            if self._contains_blocking_io(tree):
+                return 'blocking_sync'
+            
+            return 'simple_sync'
+            
+        except SyntaxError as e:
+            # Likely has top-level await that doesn't parse
+            if 'await' in str(e) or 'await' in code:
+                return 'top_level_await'
+            raise
+    
+    def _contains_await(self, node: ast.AST) -> bool:
+        """Check if node contains await expression."""
+        if isinstance(node, ast.Await):
+            return True
+        for child in ast.walk(node):
+            if isinstance(child, ast.Await):
+                return True
+        return False
+    
+    async def _execute_with_top_level_await(self, code: str) -> Any:
+        """Execute code with top-level await - NEW IMPLEMENTATION.
+        
+        Uses Python 3.11+ features for robust async execution.
+        """
+        
+        # Get base compile flags
+        base_flags = compile('', '', 'exec').co_flags
+        
+        # Add the magic flag for top-level await
+        flags = base_flags | self.PyCF_ALLOW_TOP_LEVEL_AWAIT
+        
+        try:
+            # Try direct compilation with the flag
+            compiled = compile(code, '<async_session>', 'exec', flags=flags)
+            
+            # Check if compiled code is a coroutine (Python 3.11+ pattern)
+            import inspect
+            is_coroutine_code = bool(inspect.CO_COROUTINE & compiled.co_flags)
+            
+            # Create namespace (DO NOT replace, merge!)
+            local_ns = {}
+            global_ns = self.namespace.namespace.copy()
+            
+            # Execute - may return a coroutine if CO_COROUTINE is set
+            result = eval(compiled, global_ns, local_ns)
+            
+            # Handle coroutine result with timeout (Python 3.11+)
+            if is_coroutine_code and asyncio.iscoroutine(result):
+                # Use asyncio.timeout for cleaner timeout handling
+                async with asyncio.timeout(30.0):  # 30 second timeout
+                    result = await result
+            
+            # Update namespace with changes (merge, don't replace!)
+            self.namespace.update_namespace(local_ns, source_context='async')
+            
+            return result
+            
+        except SyntaxError as e:
+            # Add context to error (Python 3.11+ exception notes)
+            if hasattr(e, 'add_note'):
+                e.add_note("Direct compilation with PyCF_ALLOW_TOP_LEVEL_AWAIT failed")
+                e.add_note("Falling back to AST transformation")
+            # Needs AST transformation - wrap in async function
+            return await self._execute_with_ast_transform(code)
+        except asyncio.TimeoutError as e:
+            # Enrich timeout error with context
+            if hasattr(e, 'add_note'):
+                e.add_note(f"Code execution timed out after 30 seconds")
+                e.add_note(f"Execution ID: {self.execution_id}")
+            raise
+    
+    async def _execute_with_ast_transform(self, code: str) -> Any:
+        """Transform code for top-level await - FALLBACK."""
+        
+        # Parse and modify AST
+        tree = ast.parse(code)
+        
+        # Wrap in async function
+        async_wrapper = ast.AsyncFunctionDef(
+            name='__async_exec__',
+            args=ast.arguments(
+                posonlyargs=[], args=[], kwonlyargs=[], 
+                kw_defaults=[], defaults=[]
+            ),
+            body=tree.body,
+            decorator_list=[],
+            returns=None
+        )
+        
+        # Create module with wrapper
+        new_tree = ast.Module(body=[async_wrapper], type_ignores=[])
+        ast.fix_missing_locations(new_tree)
+        
+        # Compile and execute
+        compiled = compile(new_tree, '<async_transform>', 'exec')
+        
+        local_ns = {}
+        global_ns = self.namespace.namespace.copy()
+        
+        exec(compiled, global_ns, local_ns)
+        
+        # Get the async function and execute it
+        async_func = local_ns['__async_exec__']
+        result = await async_func()
+        
+        return result
+
+# Resonate Durable Wrapper
+
+@resonate.register
+def durable_execute(ctx, args):
+    """Durable execution with automatic recovery."""
+    code = args['code']
+    execution_id = args['execution_id']
+    namespace = args.get('namespace', {})
+    
+    # Get dependencies from Resonate context
+    namespace_manager = ctx.get_dependency("namespace_manager")
+    
+    # Create executor instance
+    executor = AsyncExecutor(
+        resonate=ctx.resonate,
+        namespace_manager=namespace_manager,
+        execution_id=execution_id
+    )
+    
+    # Analyze code to determine execution mode
+    analysis = analyze_code(code)
+    
+    if analysis.has_top_level_await:
+        # Execute with top-level await support
+        result = yield ctx.lfc(execute_async_with_await, {
+            'executor': executor,
+            'code': code,
+            'flags': AsyncExecutor.PyCF_ALLOW_TOP_LEVEL_AWAIT
+        })
+    elif analysis.needs_blocking_io:
+        # Use thread pool for blocking I/O
+        result = yield ctx.lfc(execute_in_thread, {
+            'code': code,
+            'namespace': namespace
+        })
+    else:
+        # Simple sync execution
+        result = executor._execute_sync(code)
+    
+    return result
+
+# Initialize Resonate for local development (no server required)
+def initialize_executor_system():
+    """Initialize with Resonate in local or remote mode."""
+    import os
+    
+    if os.getenv('RESONATE_REMOTE'):
+        # Production mode with crash recovery
+        resonate = Resonate.remote(host=os.getenv('RESONATE_HOST', 'http://localhost:8001'))
+    else:
+        # Local development - no external dependencies
+        resonate = Resonate.local()
+    
+    # Register durable functions
+    resonate.register(durable_execute)
+    resonate.register(execute_async_with_await)
+    resonate.register(execute_in_thread)
+    
+    # Set up dependencies
+    resonate.set_dependency("namespace_manager", NamespaceManager())
+    
+    return resonate
+```
+
+### Phase 3: Risk Mitigation (20% effort - UPDATED by 3.11–3.13 findings)
+
+**Critical Risks from Investigation:**
+
+1. **Namespace Corruption Risk**
+   - **Issue**: IPython's `_oh` KeyError when replacing namespace
+   - **Mitigation**: ALWAYS merge namespace updates, never replace
+   - **Implementation**: Use `namespace.update()` not `namespace = {}`
+
+2. **Event Loop Conflicts**  
+   - **Issue**: Protocol messages need async context
+   - **Mitigation**: Queue messages when not in async context
+   - **Implementation**: Message buffer with `await send_pending()`; prefer compile-first to avoid wrappers that shift line numbers
+
+3. **Coroutine Leaks**
+   - **Issue**: Unawaited coroutines left in namespace
+   - **Mitigation**: Track and cleanup coroutines
+   - **Implementation**: `_pending_coroutines` registry with cleanup
+
+4. **Cancellation Complexity**
+   - **Issue**: sys.settrace doesn't work for async code
+   - **Mitigation**: Use asyncio.Task cancellation
+   - **Implementation**: Track running tasks and cancel on interrupt
+
+## Output Requirements
+
+### 1. Executive Summary
+- Build custom async executor using `PyCF_ALLOW_TOP_LEVEL_AWAIT` flag
+- Avoid IPython's namespace coupling issues entirely
+- Preserve ThreadedExecutor for blocking I/O
+- Maintain protocol message ordering through careful async management
+- Zero dependencies beyond standard library
+
+### 2. Implementation Checklist (updated)
+- [ ] Use `PyCF_ALLOW_TOP_LEVEL_AWAIT = 0x2000` flag
+- [ ] Never replace namespace entirely (merge only)
+- [ ] Prefer compile-first; keep AST wrapper only as fallback; preserve ordering and locations
+- [ ] Track pending coroutines for cleanup
+- [ ] Preserve ThreadedExecutor for blocking I/O
+- [ ] Queue protocol messages when not in async context
+
+### 3. Test Cases (CRITICAL)
+
+```python
+async def test_compile_flag_usage():
+    """Verify the magic flag enables top-level await."""
+    code = "import asyncio; result = await asyncio.sleep(0, 'test')"
+    
+    # This MUST work with our flag
+    flags = compile('', '', 'exec').co_flags | 0x2000
+    compiled = compile(code, '<test>', 'exec', flags=flags)
+    assert compiled is not None
+    
+    # Verify CO_COROUTINE flag is set (Python 3.11+ pattern)
+    import inspect
+    assert bool(inspect.CO_COROUTINE & compiled.co_flags), "CO_COROUTINE flag should be set"
+
+async def test_namespace_preservation():
+    """Ensure namespace updates don't cause KeyError."""
+    resonate = Resonate.local()
+    namespace_manager = NamespaceManager()
+    executor = AsyncExecutor(resonate, namespace_manager, 'test-id')
+    
+    # Execute code that returns a value
+    await executor.execute("result = 42")
+    
+    # This must NOT raise KeyError like IPython did
+    await executor.execute("result")  # Display hook equivalent
+    
+async def test_no_coroutine_leak():
+    """Verify coroutines are properly managed."""
+    initial_tasks = len(asyncio.all_tasks())
+    
+    await executor.execute("import asyncio; await asyncio.sleep(0)")
+    
+    # No leaked tasks
+    assert len(asyncio.all_tasks()) == initial_tasks
+
+def test_resonate_local_mode():
+    """Test execution works without server."""
+    resonate = Resonate.local()
+    
+    result = durable_execute.run("test-1", {
+        'code': "result = 2 + 2",
+        'execution_id': "test-1"
+    })
+    assert result == 4
+
+def test_resonate_recovery():
+    """Test execution recovers from crash."""
+    resonate = Resonate.remote()  # Requires server
+    
+    # Start execution that will crash
+    promise = durable_execute.rpc("test-2", {
+        'code': "import random; x = 1/random.choice([0, 1])",
+        'execution_id': "test-2"
+    })
+    
+    # Retry will resume from checkpoint
+    result = durable_execute.run("test-2", {'code': "x = 1", 'execution_id': "test-2"})
+    assert result == 1
+```
+
+## Calibration
+
+<context_gathering>
+- Search depth: LOW (we know the solution from investigation)
+- Maximum tool calls: 10-15 (verification only)
+- Early stop: When compile flag works with test code
+</context_gathering>
+
+## Non-Negotiables (REFINED)
+
+1. **No IPython Dependency**: Build our own implementation
+2. **Use PyCF_ALLOW_TOP_LEVEL_AWAIT**: This is THE key to top-level await
+3. **Preserve Namespace Control**: No `_oh` or IPython internals
+4. **Maintain ThreadedExecutor**: It works well for blocking I/O
+
+## Success Criteria (REFINED with Resonate + 3.11–3.13)
+
+- [ ] Top-level await works with `PyCF_ALLOW_TOP_LEVEL_AWAIT` flag (exec/eval decision matrix)
+- [ ] No namespace KeyErrors (avoided IPython's pitfall)
+- [ ] Protocol messages maintain order via Resonate promises
+- [ ] Blocking I/O still uses threads
+- [ ] Zero external dependencies in local mode (Resonate.local())
+- [ ] Automatic recovery in remote mode (Resonate.remote())
+- [ ] Execution state persists across crashes
+- [ ] Dependencies injected via Resonate context
+
+## Critical Implementation Note
+
+**DO NOT** attempt to replicate IPython's InteractiveShell complexity. We need ONLY:
+1. The compile flag for top-level await
+2. AST transformation for edge cases  
+3. Careful namespace merging (not replacement)
+4. Protocol message queuing
+
+This is ~400 lines of code, not 2000 like IPython.
+
+## Python 3.11+ Patterns to Use
+
+### 1. Structured Concurrency with TaskGroup
+```python
+async def execute_parallel_tasks(tasks: List[Callable]) -> List[Any]:
+    """Execute multiple async tasks with structured concurrency."""
+    async with asyncio.TaskGroup() as tg:
+        futures = [tg.create_task(task()) for task in tasks]
+    # All tasks complete or all cancelled on error
+    return [f.result() for f in futures]
+```
+
+### 2. Timeout with asyncio.timeout()
+```python
+async def execute_with_timeout(coro, timeout: float):
+    """Execute coroutine with timeout (Python 3.11+)."""
+    async with asyncio.timeout(timeout):
+        return await coro
+```
+
+### 3. Exception Notes for Context
+```python
+try:
+    result = await execute(code)
+except Exception as e:
+    # Add execution context (Python 3.11+)
+    e.add_note(f"Execution ID: {execution_id}")
+    e.add_note(f"Code snippet: {code[:100]}")
+    raise
+```
+
+### 4. CO_COROUTINE Flag Checking
+```python
+import inspect
+
+# Check if compiled code will return a coroutine
+compiled = compile(code, '<exec>', 'exec', flags=flags)
+is_coroutine_code = bool(inspect.CO_COROUTINE & compiled.co_flags)
+```
+
+## Forward Compatibility Notes
+
+### Python 3.12+ Subinterpreters (PEP 684)
+When available, consider using subinterpreters instead of subprocesses for better performance:
+```python
+# Future pattern when interpreters module is available
+if sys.version_info >= (3, 12) and hasattr(sys, '_interpreters'):
+    # Use subinterpreter for isolation
+    interp = interpreters.create()
+    result = interp.exec(code)
+else:
+    # Fall back to subprocess isolation
+    result = subprocess_executor.execute(code)
+```

--- a/docs/async_capability_prompts/current/11_prompt_capability_system.md
+++ b/docs/async_capability_prompts/current/11_prompt_capability_system.md
@@ -1,0 +1,415 @@
+# Capability Injection System Planning Prompt (REFINED with Resonate)
+
+## Your Mission
+
+You are tasked with extending the NamespaceManager to support a comprehensive capability injection system using Resonate's dependency injection. Based on testing, capability injection works excellently - focus on using Resonate promises for protocol communication and Resonate dependencies for capability management.
+
+## Context Gathering Requirements
+
+### 1. Problem History (NEW INSIGHT)
+- **Security Preprocessors**: IPython's string-level preprocessors are easily bypassed
+- **Key Lesson**: Security must be enforced at capability level, not code level
+- **Success Story**: Dynamic capability injection tested successfully with IPython
+
+### 2. Protocol Message Complexity (CRITICAL DISCOVERY)
+- **Event Loop Issue**: `RuntimeError: no running event loop` when sending messages from sync
+- **Solution Pattern**: Queue messages, send when in async context
+- **Invariant**: Never call `asyncio.create_task()` outside event loop
+
+### 3. Existing Infrastructure (VALIDATED)
+- **Capability Pattern**: Injection into namespace works perfectly
+- **Dynamic Management**: Add/remove capabilities at runtime succeeded
+- **Security Policies**: Can be enforced at injection time
+
+## Planning Methodology
+
+### Phase 1: Analysis (20% effort - REDUCED, pattern proven)
+<context_gathering>
+Goal: Focus on async/sync bridge for protocol messages
+Stop when: Message queueing pattern is clear
+Depth: Study asyncio event loop detection and queuing
+</context_gathering>
+
+### Phase 2: Solution Design (60% effort - INCREASED for robustness)
+
+**Protocol-Aware Capability Base (REFINED with Resonate Promises):**
+
+```python
+# src/subprocess/capabilities.py
+import json
+import time
+from typing import Any, Callable, Dict, Optional
+import uuid
+from abc import ABC, abstractmethod
+from resonate_sdk import Resonate
+
+class Capability(ABC):
+    """Base class using Resonate promises for durability."""
+    
+    def __init__(self, resonate: Resonate):
+        self.resonate = resonate
+    
+    def create_promise_for_request(
+        self,
+        request_id: str,
+        message_type: str,
+        timeout: Optional[float] = None
+    ):
+        """Create durable promise for request/response."""
+        promise_data = {
+            'type': message_type,
+            'created_at': time.time()
+        }
+        
+        timeout_ms = None
+        if timeout:
+            timeout_ms = int((time.time() + timeout) * 1000)
+        
+        return self.resonate.promises.create(
+            id=request_id,
+            timeout=timeout_ms,
+            data=json.dumps(promise_data)
+        )
+    
+    @abstractmethod
+    def get_name(self) -> str:
+        """Get capability name for injection."""
+        pass
+    
+    @abstractmethod
+    def get_implementation(self) -> Callable:
+        """Get the implementation function."""
+        pass
+
+class InputCapability(Capability):
+    """Input using Resonate promises for HITL."""
+    
+    def __init__(self, resonate: Resonate, execution_id: str):
+        super().__init__(resonate)
+        self.execution_id = execution_id
+    
+    def get_name(self) -> str:
+        return 'input'
+    
+    def get_implementation(self) -> Callable:
+        """Return function that uses Resonate promises."""
+        def input_with_promise(prompt: str = "") -> str:
+            # This will be called from inside a durable function
+            # so it needs to use yield for Resonate context
+            request_id = f"input:{self.execution_id}:{uuid.uuid4()}"
+            
+            # Create promise for this input request
+            promise = self.create_promise_for_request(
+                request_id=request_id,
+                message_type='input_request',
+                timeout=300.0  # 5 minutes
+            )
+            
+            # UI will resolve this promise
+            # resonate.promises.resolve(id=request_id, data=user_input)
+            
+            # Return the promise ID so the durable function can wait
+            return request_id
+        
+        return input_with_promise
+
+# Usage in a durable function
+@resonate.register
+def execute_with_input(ctx, args):
+    """Execute code that needs user input."""
+    input_cap = ctx.get_dependency("input")
+    
+    # Create promise for input
+    promise_id = input_cap("Enter your name: ")
+    
+    # Wait for promise resolution
+    promise = yield ctx.promise(id=promise_id)
+    user_input = yield promise
+    
+    return json.loads(user_input)['data']
+```
+
+**Security Policy with Capability-Level Enforcement (REFINED):**
+
+```python
+# src/subprocess/security_policy.py
+from enum import Enum
+from typing import Set, Dict, Any, Callable
+
+class SecurityLevel(Enum):
+    """Security levels based on investigation."""
+    SANDBOX = "sandbox"      # Minimal - no I/O
+    RESTRICTED = "restricted" # Local I/O only
+    STANDARD = "standard"    # Network + I/O
+    TRUSTED = "trusted"      # Most capabilities
+    UNRESTRICTED = "unrestricted"  # All capabilities
+
+class SecurityPolicy:
+    """Capability-level security (not code-level)."""
+    
+    # Capability sets refined from testing
+    CAPABILITY_SETS = {
+        SecurityLevel.SANDBOX: {
+            'print',  # Output only
+            'display', # Rich display
+        },
+        SecurityLevel.RESTRICTED: {
+            'print', 'display', 'input',  # Basic I/O
+            'read_file',  # Read only
+        },
+        SecurityLevel.STANDARD: {
+            'print', 'display', 'input',
+            'read_file', 'write_file',  # File I/O
+            'fetch',  # Network read
+        },
+        SecurityLevel.TRUSTED: {
+            'print', 'display', 'input',
+            'read_file', 'write_file', 
+            'fetch', 'websocket',  # Full network
+            'query',  # Database
+        },
+        SecurityLevel.UNRESTRICTED: '*'  # Everything
+    }
+    
+    def __init__(self, level: SecurityLevel = SecurityLevel.STANDARD):
+        self.level = level
+        self._allowed = self._compute_allowed()
+        self._blocked = set()  # Explicitly blocked
+        # CRITICAL: No code preprocessors - they don't work
+        self._capability_validators: Dict[str, Callable] = {}
+    
+    def is_allowed(self, capability_name: str) -> bool:
+        """Check at capability level, not code level."""
+        if capability_name in self._blocked:
+            return False
+        if self._allowed == '*':
+            return True
+        return capability_name in self._allowed
+    
+    def add_capability_validator(self, cap_name: str, validator: Callable):
+        """Add runtime validator for capability usage."""
+        # This is more effective than code preprocessors
+        self._capability_validators[cap_name] = validator
+```
+
+**Enhanced NamespaceManager with Resonate Dependencies:**
+
+```python
+# Extensions to src/subprocess/namespace.py
+from resonate_sdk import Resonate
+
+class NamespaceManager:
+    """Manages namespace with Resonate dependency injection."""
+    
+    def __init__(self, resonate: Resonate):
+        self.resonate = resonate
+        self._namespace = {}
+        self._security_policy = None
+    
+    def register_capabilities(self, security_policy: SecurityPolicy):
+        """Register all capabilities as Resonate dependencies."""
+        self._security_policy = security_policy
+        
+        # Core I/O capabilities
+        if security_policy.is_allowed("input"):
+            self.resonate.set_dependency("input", InputCapability)
+        if security_policy.is_allowed("print"):
+            self.resonate.set_dependency("print", PrintCapability)
+        if security_policy.is_allowed("display"):
+            self.resonate.set_dependency("display", DisplayCapability)
+        
+        # File capabilities
+        if security_policy.is_allowed("read_file"):
+            self.resonate.set_dependency("read_file", FileReadCapability)
+        if security_policy.is_allowed("write_file"):
+            self.resonate.set_dependency("write_file", FileWriteCapability)
+        
+        # Network capabilities
+        if security_policy.is_allowed("fetch"):
+            self.resonate.set_dependency("fetch", FetchCapability)
+        if security_policy.is_allowed("websocket"):
+            self.resonate.set_dependency("websocket", WebSocketCapability)
+    
+    def inject_into_namespace(self, execution_id: str):
+        """Inject capabilities into execution namespace."""
+        # This is called from within a durable function
+        # Capabilities are accessed via context.get_dependency()
+        
+        # For backward compatibility, create wrapper functions
+        def create_capability_wrapper(cap_name: str):
+            def wrapper(*args, **kwargs):
+                # This will be resolved inside durable function
+                return f"RESONATE_CAP:{cap_name}:{args}:{kwargs}"
+            return wrapper
+        
+        # Inject wrappers for allowed capabilities
+        for cap_name in ["input", "print", "display", "read_file", 
+                         "write_file", "fetch", "websocket"]:
+            if self._security_policy.is_allowed(cap_name):
+                self._namespace[cap_name] = create_capability_wrapper(cap_name)
+
+# Usage in durable function
+@resonate.register
+def execute_with_capabilities(ctx, args):
+    """Execute with capability access via Resonate."""
+    code = args['code']
+    execution_id = args['execution_id']
+    
+    # Get capabilities from dependencies
+    input_cap = ctx.get_dependency("input") if ctx.has_dependency("input") else None
+    print_cap = ctx.get_dependency("print") if ctx.has_dependency("print") else None
+    
+    # Create namespace with capabilities
+    namespace = {
+        'input': input_cap.get_implementation() if input_cap else None,
+        'print': print_cap.get_implementation() if print_cap else None,
+        '__builtins__': __builtins__,
+    }
+    
+    # Execute code with capabilities
+    exec(code, namespace)
+    
+    return namespace.get('result')
+```
+
+### Resonate Promise Integration (Replaces Protocol Bridge)
+
+With Resonate, the Protocol Bridge infrastructure is replaced by durable promises. Capabilities use Resonate's promise system for request/response patterns:
+
+- **Durable promises**: Survive crashes and restarts
+- **Built-in correlation**: Promise IDs serve as correlation IDs
+- **Automatic cleanup**: Promises expire based on timeouts
+- **HITL support**: External systems can resolve promises
+- **Distributed by design**: Works across processes and machines
+
+**Integration Pattern with Resonate:**
+
+```python
+class FileReadCapability(Capability):
+    """File operations using Resonate promises."""
+    
+    def read_file_with_promise(self, path: str) -> str:
+        """Create promise for file read operation."""
+        request_id = f"file_read:{self.execution_id}:{uuid.uuid4()}"
+        
+        # Create durable promise
+        self.resonate.promises.create(
+            id=request_id,
+            timeout=int((time.time() + 10) * 1000),
+            data=json.dumps({'path': path, 'operation': 'read'})
+        )
+        
+        # External file service will:
+        # 1. Poll for pending file_read promises
+        # 2. Perform the file operation
+        # 3. Resolve: resonate.promises.resolve(id=request_id, data=content)
+        
+        return request_id  # Return promise ID for durable function to await
+
+@resonate.register
+def execute_with_file_read(ctx, args):
+    """Durable function that reads a file."""
+    file_cap = ctx.get_dependency("read_file")
+    
+    # Create promise for file read
+    promise_id = file_cap.read_file_with_promise("/path/to/file.txt")
+    
+    # Wait for external resolution
+    promise = yield ctx.promise(id=promise_id)
+    content = yield promise
+    
+    return json.loads(content)['data']
+```
+
+This removes the need for custom routing logic. Resonate handles:
+- Promise creation with unique IDs
+- Durable storage of promise state
+- External resolution from any process
+- Automatic timeout and cleanup
+- Recovery after crashes
+
+**Capability Types and Promise Usage:**
+
+| Capability Type | Uses Resonate Promises | Example |
+|----------------|----------------------|---------|
+| Send-only | No | `print`, `log`, `display` |
+| Request-Response | **Yes** | `input`, `read_file`, `query` |
+| HITL | **Yes** | `approve`, `review`, `input` |
+| Scheduled | **Yes** | `cron`, `delayed`, `retry` |
+
+### Phase 3: Risk Assessment (20% effort)
+
+**Refined Risks from Investigation:**
+
+1. **Event Loop Detection**
+   - **Issue**: RuntimeError when no event loop
+   - **Mitigation**: Queue messages, flush when async
+   - **Test**: Call capability from both sync and async
+
+2. **Security Bypass**
+   - **Issue**: Code preprocessors easily bypassed
+   - **Mitigation**: Enforce at capability injection only
+   - **Test**: Try to bypass with eval/exec
+
+3. **Message Correlation**
+   - **Issue**: Responses arriving out of order
+   - **Mitigation**: Request ID tracking with futures
+   - **Test**: Concurrent capability calls
+
+## Output Requirements
+
+### 1. Executive Summary
+- Capability injection works perfectly (proven in tests)
+- Focus on async/sync context handling for protocol messages
+- Security at capability level, not code level
+- Message queueing prevents event loop errors
+
+### 2. Implementation Checklist
+- [ ] Queue messages when not in async context
+- [ ] Flush queues when entering async context
+- [ ] Security at injection time, not execution time
+- [ ] Hybrid implementations for sync/async contexts
+- [ ] Request ID correlation for concurrent calls
+
+### 3. Critical Test Cases
+
+```python
+async def test_capability_from_sync_context():
+    """Test capability works when called from sync code."""
+    # This was failing with RuntimeError
+    code = "result = input('test>')"
+    await executor.execute(code)  # Should queue, not crash
+
+async def test_capability_from_async_context():
+    """Test capability works in async code."""
+    code = "result = await fetch('http://example.com')"
+    await executor.execute(code)  # Should work directly
+
+async def test_security_bypass_prevention():
+    """Test that security can't be bypassed."""
+    policy = SecurityPolicy(SecurityLevel.SANDBOX)
+    namespace.set_security_policy(policy)
+    
+    # Should fail at injection
+    with pytest.raises(SecurityError):
+        namespace.inject_capability('fetch')
+    
+    # Even with eval tricks
+    code = "eval('fetch')('http://evil.com')"
+    # fetch shouldn't exist in namespace
+```
+
+## Non-Negotiables (REFINED)
+
+1. **Message Queueing**: Must handle non-async contexts
+2. **Security at Capability Level**: Not code analysis
+3. **Hybrid Implementations**: Work in any context
+4. **No Code Preprocessors**: They don't work reliably
+
+## Success Criteria
+
+- [ ] No RuntimeError from event loop detection
+- [ ] Capabilities work from sync and async code
+- [ ] Security policies enforced at injection
+- [ ] Messages queued and flushed properly
+- [ ] Concurrent capability calls work correctly

--- a/docs/async_capability_prompts/current/12_prompt_namespace_persistence.md
+++ b/docs/async_capability_prompts/current/12_prompt_namespace_persistence.md
@@ -1,0 +1,435 @@
+# Namespace Persistence Across Async/Sync Boundaries Planning Prompt (REFINED with Resonate)
+
+## Your Mission
+
+You are tasked with ensuring namespace persistence works correctly across async and sync execution contexts using Resonate's durable state management. Based on investigation, the critical insight remains: **NEVER replace the namespace dictionary entirely** - this causes KeyError failures. Always merge updates while preserving execution engine internals. Resonate now provides durability for the namespace across crashes and restarts.
+
+## Context Gathering Requirements
+
+### 1. Problem History (CRITICAL DISCOVERY)
+- **IPython Namespace Failure**: Replacing `user_ns` caused `KeyError: '_oh'`
+- **Root Cause**: Execution engines maintain internal variables in namespace
+- **Key Lesson**: Must preserve engine internals (_oh, Out, In, _, __, ___)
+- **Solution**: Always merge updates, never replace
+
+### 2. Threading Complexity (NEW INSIGHT)  
+- **Issue**: Namespace accessed from event loop AND thread pool
+- **Discovery**: Simple dict not thread-safe across contexts
+- **Requirement**: Need RLock for all namespace operations
+- **Pattern**: Copy for thread execution, merge results back
+
+### 3. Coroutine Management (INVESTIGATION FINDING)
+- **Problem**: Unawaited coroutines leak in namespace
+- **IPython Approach**: Complex coroutine tracking
+- **Our Solution**: Simpler - track and cleanup on execution boundary
+
+## Planning Methodology
+
+### Phase 1: Analysis (20% effort - REDUCED, problem understood)
+<context_gathering>
+Goal: Understand Python's namespace sharing mechanics
+Stop when: Thread-safe update pattern is clear
+Depth: Focus on threading.RLock and dict.update() semantics
+</context_gathering>
+
+### Phase 2: Solution Design (60% effort - FOCUSED on robustness)
+
+**Durable Namespace Manager with Resonate:**
+
+```python
+# src/subprocess/namespace.py - RESONATE ENHANCED
+import json
+import threading
+from typing import Any, Dict, Set, Optional
+from resonate_sdk import Resonate
+
+class DurableNamespaceManager:
+    """Namespace manager with Resonate durability and critical safety improvements."""
+    
+    def __init__(self, resonate: Resonate, execution_id: str):
+        self.resonate = resonate
+        self.execution_id = execution_id
+        
+        # CRITICAL: Thread-safe access still needed for local operations
+        self._namespace_lock = threading.RLock()
+        
+        # The actual namespace - can be recovered from Resonate
+        self._namespace = self._initialize_or_recover_namespace()
+        
+        # CRITICAL: Preserve engine internals
+        self._preserved_keys: Set[str] = set()
+        self._init_engine_internals()
+    
+    def _initialize_or_recover_namespace(self) -> Dict[str, Any]:
+        """Initialize or recover namespace from Resonate."""
+        namespace_id = f"namespace:{self.execution_id}"
+        
+        try:
+            # Try to recover existing namespace
+            promise = self.resonate.promises.get(namespace_id)
+            if promise and promise.state == 'resolved':
+                return json.loads(promise.data)
+        except:
+            pass
+        
+        # Initialize fresh namespace
+        return {
+            "__name__": "__main__",
+            "__doc__": None,
+            "__package__": None,
+            "__loader__": None,
+            "__spec__": None,
+            "__annotations__": {},
+            "__builtins__": __builtins__,
+        }
+    
+    def _init_engine_internals(self):
+        """Initialize engine internals that must be preserved."""
+        # These are what IPython uses - we preserve similar
+        engine_internals = {
+            '_': None,           # Last result
+            '__': None,          # Second to last
+            '___': None,         # Third to last  
+            '_exit_code': 0,     # Last exit code
+            '_exception': None,  # Last exception
+        }
+        
+        with self._namespace_lock:
+            self._namespace.update(engine_internals)
+            self._preserved_keys.update(engine_internals.keys())
+    
+    def persist_namespace(self):
+        """Persist namespace to Resonate for durability."""
+        namespace_id = f"namespace:{self.execution_id}"
+        
+        # Serialize namespace (skip non-serializable items)
+        serializable_ns = {}
+        for key, value in self._namespace.items():
+            try:
+                json.dumps(value)  # Test if serializable
+                serializable_ns[key] = value
+            except:
+                # Skip functions, modules, etc.
+                pass
+        
+        # Create or update promise with namespace state
+        self.resonate.promises.resolve(
+            id=namespace_id,
+            data=json.dumps(serializable_ns)
+        )
+    
+    @property
+    def namespace(self) -> Dict[str, Any]:
+        """Get namespace snapshot for reading."""
+        with self._namespace_lock:
+            # Return a snapshot to prevent modification
+            return dict(self._namespace)
+    
+    def get_for_execution(self, execution_context: str) -> Dict[str, Any]:
+        """Get namespace for code execution."""
+        with self._namespace_lock:
+            if execution_context == 'thread':
+                # For thread execution, return a copy
+                return self._namespace.copy()
+            else:
+                # For async execution, return direct reference
+                # (async is single-threaded within event loop)
+                return self._namespace
+    
+    def update_namespace(
+        self,
+        updates: Dict[str, Any],
+        source_context: str = "unknown"
+    ) -> None:
+        """CRITICAL: Merge updates, never replace."""
+        
+        with self._namespace_lock:
+            # Filter out None and empty values
+            filtered_updates = {}
+            
+            for key, value in updates.items():
+                # Skip engine internals from updates
+                if key in self._preserved_keys and source_context != "engine":
+                    continue
+                
+                # With Resonate, coroutines are handled differently
+                # Resonate uses generators with yield, not asyncio coroutines
+                if hasattr(value, '__name__') and 'resonate' in str(type(value)):
+                    # This is a Resonate durable function
+                    filtered_updates[key] = value
+                    continue
+                
+                # Normal values
+                filtered_updates[key] = value
+            
+            # CRITICAL: Use update(), never assign
+            self._namespace.update(filtered_updates)
+            
+            # Update engine internals if execution completed
+            if source_context in ['async', 'thread']:
+                self._update_result_history(filtered_updates)
+    
+    def _update_result_history(self, updates: Dict[str, Any]):
+        """Update result history like IPython but simpler."""
+        # Look for a result value
+        result = updates.get('_result') or updates.get('__result__')
+        
+        if result is not None:
+            with self._namespace_lock:
+                # Shift history
+                self._namespace['___'] = self._namespace.get('__')
+                self._namespace['__'] = self._namespace.get('_')
+                self._namespace['_'] = result
+    
+    def _create_sync_wrapper(self, async_func: Any) -> Any:
+        """Create wrapper for async function callable from sync."""
+        
+        def wrapper(*args, **kwargs):
+            """Wrapper that returns coroutine."""
+            coro = async_func(*args, **kwargs)
+            # Track it
+            self._pending_coroutines.add(coro)
+            return coro
+        
+        wrapper.__name__ = async_func.__name__
+        wrapper.__doc__ = async_func.__doc__
+        wrapper._is_async_wrapper = True
+        
+        return wrapper
+    
+    def cleanup_coroutines(self) -> int:
+        """Clean up pending coroutines."""
+        cleaned = 0
+        
+        # Get coroutines to clean (weak refs may be gone)
+        to_clean = list(self._pending_coroutines)
+        
+        for coro in to_clean:
+            try:
+                coro.close()
+                cleaned += 1
+            except:
+                pass  # Already closed or running
+        
+        self._pending_coroutines.clear()
+        return cleaned
+    
+    def merge_thread_results(
+        self,
+        thread_namespace: Dict[str, Any],
+        original_namespace: Dict[str, Any]
+    ) -> None:
+        """Merge results from thread execution."""
+        
+        # Calculate changes
+        changes = {}
+        for key, value in thread_namespace.items():
+            if key not in original_namespace or original_namespace[key] != value:
+                changes[key] = value
+        
+        # Apply changes
+        self.update_namespace(changes, source_context='thread')
+```
+
+**Execution with Resonate Durable Functions:**
+
+```python
+# src/subprocess/durable_execution.py
+from resonate_sdk import Resonate
+
+@resonate.register
+def durable_execute_with_namespace(ctx, args):
+    """Execute code with durable namespace management."""
+    code = args['code']
+    execution_id = args['execution_id']
+    
+    # Get namespace manager from dependencies
+    namespace_manager = ctx.get_dependency("namespace_manager")
+    
+    # Initialize or recover namespace for this execution
+    namespace = namespace_manager.get_for_execution(execution_id)
+    
+    # Local namespace for this execution
+    local_ns = {}
+    
+    try:
+        # Compile and execute
+        compiled = compile(code, f'<execution:{execution_id}>', 'exec')
+        exec(compiled, namespace, local_ns)
+        
+        # CRITICAL: Merge updates, never replace
+        namespace_manager.update_namespace(local_ns, 'durable')
+        
+        # Persist namespace state to Resonate
+        yield ctx.lfc(namespace_manager.persist_namespace)
+        
+        # Check for result
+        result = local_ns.get('_result') or namespace.get('_')
+        
+        return result
+        
+    except Exception as e:
+        # Store exception in namespace
+        namespace_manager.update_namespace(
+            {'_exception': e},
+            source_context='engine'
+        )
+        # Persist error state
+        yield ctx.lfc(namespace_manager.persist_namespace)
+        raise
+    
+    def execute_in_thread(self, code: str, execution_id: str) -> Any:
+        """Execute in thread with namespace safety."""
+        self._execution_id = execution_id
+        
+        # Get namespace copy for thread
+        ns_copy = self.namespace.get_for_execution('thread')
+        original_ns = ns_copy.copy()
+        
+        # Local namespace
+        local_ns = {}
+        
+        try:
+            # Execute in thread's copy
+            compiled = compile(code, '<thread>', 'exec')
+            exec(compiled, ns_copy, local_ns)
+            
+            # Merge changes back to main namespace
+            ns_copy.update(local_ns)
+            self.namespace.merge_thread_results(ns_copy, original_ns)
+            
+            return local_ns.get('_result')
+            
+        except Exception as e:
+            # Store exception in namespace
+            self.namespace.update_namespace(
+                {'_exception': e},
+                source_context='engine'
+            )
+            raise
+```
+
+### Phase 3: Risk Assessment (20% effort)
+
+**Critical Risks from Investigation:**
+
+1. **Namespace Replacement Error**
+   - **Issue**: KeyError when namespace replaced
+   - **Mitigation**: Always use update(), never assign
+   - **Test**: Verify _ and __ work after execution
+
+2. **Thread Safety Violation**
+   - **Issue**: Dict corruption from concurrent access
+   - **Mitigation**: RLock on all operations
+   - **Test**: Concurrent thread and async execution
+
+3. **Coroutine Leaks**
+   - **Issue**: Unawaited coroutines accumulate
+   - **Mitigation**: WeakSet tracking with cleanup
+   - **Test**: Check coroutine count after execution
+
+## Output Requirements
+
+### 1. Executive Summary
+- Never replace namespace dictionary (causes KeyError) - **Critical lesson preserved**
+- Always merge updates with thread safety - **Still required**
+- Resonate provides durability and crash recovery - **NEW capability**
+- Namespace as durable state across executions - **NEW with Resonate**
+- Preserve engine internals (_, __, ___) - **Always critical**
+
+### Benefits of Resonate Integration:
+1. **Crash Recovery**: Namespace survives process crashes
+2. **Distributed State**: Share namespace across workers
+3. **Simplified Coroutines**: No async/await complexity with yield
+4. **Automatic Persistence**: Built into execution lifecycle
+5. **Time Travel**: Can recover namespace from any point
+
+### 2. Critical Implementation Rules
+- [ ] NEVER use `self._namespace = {}`
+- [ ] ALWAYS use `self._namespace.update()`
+- [ ] ALWAYS acquire lock before namespace access
+- [ ] TRACK all coroutines in WeakSet
+- [ ] PRESERVE engine internal variables
+- [ ] COPY namespace for thread execution
+
+### 3. Test Cases
+
+```python
+def test_namespace_preservation():
+    """Test that engine internals are preserved."""
+    resonate = Resonate.local()
+    manager = DurableNamespaceManager(resonate, 'test-1')
+    
+    # Execute code that returns value
+    manager.update_namespace({'result': 42}, 'durable')
+    
+    # Check internals exist (would KeyError in IPython bug)
+    ns = manager.namespace
+    assert '_' in ns  # Must exist
+    assert '__' in ns  # Must exist
+
+def test_namespace_recovery():
+    """Test namespace recovery after crash."""
+    resonate = Resonate.remote()  # Requires server
+    
+    # First execution creates namespace
+    result1 = durable_execute_with_namespace.run("exec-1", {
+        'code': 'x = 42',
+        'execution_id': 'exec-1'
+    })
+    
+    # Simulate crash and recovery
+    # Namespace should be recovered from Resonate
+    result2 = durable_execute_with_namespace.run("exec-1", {
+        'code': 'result = x * 2',  # Uses x from recovered namespace
+        'execution_id': 'exec-1'
+    })
+    
+    assert result2 == 84  # Proves namespace was recovered
+
+def test_namespace_durability():
+    """Test namespace persists across executions."""
+    resonate = Resonate.local()
+    resonate.set_dependency("namespace_manager", DurableNamespaceManager)
+    
+    # Register durable function
+    @resonate.register
+    def test_execution(ctx, args):
+        nm = ctx.get_dependency("namespace_manager")
+        namespace = nm.get_for_execution(args['exec_id'])
+        
+        # Execute code
+        exec(args['code'], namespace)
+        
+        # Update and persist
+        nm.update_namespace(namespace, 'durable')
+        yield ctx.lfc(nm.persist_namespace)
+        
+        return namespace.get('result')
+    
+    # Multiple executions share namespace
+    test_execution.run("test-1", {'exec_id': 'shared', 'code': 'a = 1'})
+    test_execution.run("test-2", {'exec_id': 'shared', 'code': 'b = 2'})
+    result = test_execution.run("test-3", {'exec_id': 'shared', 'code': 'result = a + b'})
+    
+    assert result == 3  # Namespace persisted across executions
+```
+
+## Non-Negotiables (REFINED with Resonate)
+
+1. **No Namespace Replacement**: Always merge (critical lesson preserved)
+2. **Thread Safety**: RLock still required for local operations
+3. **Resonate Integration**: Namespace as durable dependency
+4. **Engine Internals**: Must be preserved (_, __, ___)
+5. **Persistence Strategy**: Serialize only JSON-compatible values
+
+## Success Criteria (Enhanced with Resonate)
+
+- [ ] No KeyError from namespace operations (preserved lesson)
+- [ ] Thread-safe concurrent access (still required)
+- [ ] Namespace survives process crashes (NEW with Resonate)
+- [ ] Engine internals preserved (_, __, ___)
+- [ ] Works across async/sync/thread contexts
+- [ ] Namespace state recoverable from Resonate promises
+- [ ] Automatic persistence on execution boundaries
+- [ ] Shared namespace across distributed workers (remote mode)


### PR DESCRIPTION
Restore frequently referenced reference docs to master so @-mentions fuzzy-find correctly:

- docs/async_capability_prompts/current/{00_foundation_resonate,10_prompt_async_executor,11_prompt_capability_system,12_prompt_namespace_persistence}.md
- FOUNDATION_FIX_PLAN.md
- PHASE_3_PR_PLANS.md

These were previously moved to `workspace` during cleanup. They are regularly referenced and should live on master for discoverability.

Note: PDFs remain on `workspace`. If we need them on master, we can add via Git LFS in a follow-up.
