### PR TITLE
docs: add issue conventions and templates; link from README/CONTRIBUTING; streamline AGENTS

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,53 @@
+---
+name: Feature / Refactor / Hardening
+about: Propose a feature, refactor, or hardening change with clear scope and invariants
+title: "<WORKSTREAM>-NNN — <concise action>"
+labels: []
+assignees: []
+---
+
+<!-- Please read docs/PROCESS/ISSUE_CONVENTIONS.md before filing. Fill all sections. -->
+
+## TL;DR
+- 
+
+## Background / Problem
+- 
+
+## Scope (In / Out)
+- In:
+- Out:
+
+## Design Direction
+- Approach:
+- Env flags + defaults (if any):
+
+## Affected Paths
+- src/.../...
+- src/.../...
+
+## Core Invariants
+- 
+
+## Observability
+- Metrics / logs (incl. warn-once policy):
+- Redaction policy (if applicable):
+
+## Test Plan
+- Unit:
+- Integration / E2E:
+- Filenames / fixtures:
+
+## Acceptance Criteria
+- 
+
+## Dependencies & Rollout
+- Depends on: #
+- Rollout: <flag name> (default OFF)
+
+## Risks & Mitigations
+- 
+
+## Docs
+- Specs/API/changelog to update:
+

--- a/.github/ISSUE_TEMPLATE/meta.md
+++ b/.github/ISSUE_TEMPLATE/meta.md
@@ -1,0 +1,31 @@
+---
+name: Meta / Process / Docs
+about: Improve templates, processes, or documentation quality
+title: "META-XXX — <concise action>"
+labels: ["type:process"]
+assignees: []
+---
+
+## TL;DR
+- 
+
+## Background / Problem
+- 
+
+## Scope (In / Out)
+- In:
+- Out:
+
+## Plan
+- Steps / owners:
+
+## Affected Paths
+- docs/.../...
+- .github/.../...
+
+## Acceptance Criteria
+- 
+
+## Dependencies
+- Depends on: #
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,22 @@ uv run pytest --timeout=30                # guard long tests
 - Subject in imperative mood, ≤72 chars; include context in body and breaking changes under `BREAKING CHANGE:`.
 - PRs: clear description, linked issues, tests/fixtures updated, docs touched when behavior changes; ensure lint, type checks, and tests pass.
 
+## Issue Conventions (agents & maintainers)
+- For how we write and manage issues and milestones, see:
+  - `docs/PROCESS/ISSUE_CONVENTIONS.md` — covers milestone naming, issue title format, label taxonomy, required sections, per‑workstream invariants, rollout/flags, and a quality checklist.
+  - `.github/ISSUE_TEMPLATE/` — ready‑to‑use templates for feature/refactor/hardening and meta/process issues.
+  - README “Contributing” — quick links and where to file.
+  
+Use those references when creating/updating issues so titles, labels, and sections stay consistent and reviewable.
+
 ## Security & Configuration Tips
 - Each `Session` runs isolated; respect limits (≈512MB memory, 30s timeout, ~100 FDs).
 - Do not use `dont_inherit=True` in `compile()` (cancellation breaks).
 - Maintain message correlation IDs and merge‑only namespace policy.
+
+## Documentation Practices
+- Prefer one canonical document for a topic and link to it from README and here.
+- Avoid duplicating guidance across files; update the canonical doc and keep pointers evergreen.
+
+## References
+- Issue conventions: `docs/PROCESS/ISSUE_CONVENTIONS.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,7 @@ We maintain consistent, high‑quality issues so ownership, risks, sequencing, a
 
 ## Debugging and Troubleshooting
 
-- Check `docs/investigations/troubleshooting/investigation_log.json` for historical issues
-- Use the isolated tests in `tests/isolated/` for debugging specific components
+- Use targeted unit/integration tests for the component under investigation
 - Development artifacts are stored in `.dev/` (not tracked by git)
 
 ## Documentation
@@ -128,7 +127,6 @@ We maintain consistent, high‑quality issues so ownership, risks, sequencing, a
 - Update docstrings for API changes
 - Add examples to README.md for new features
 - Document architectural decisions in `docs/architecture/`
-- Keep investigation notes in `docs/investigations/`
 
 ## Getting Help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,17 @@ ruff check src/ tests/
 6. Push to your fork (`git push origin feature/amazing-feature`)
 7. Open a Pull Request
 
+## Issue Conventions and Templates
+
+We maintain consistent, high‑quality issues so ownership, risks, sequencing, and acceptance criteria are obvious.
+
+- Read: `docs/PROCESS/ISSUE_CONVENTIONS.md` for titles, labels, required sections, rollout/flags, and core invariants by workstream.
+- Use GitHub templates when filing issues:
+  - Feature / Refactor / Hardening: `.github/ISSUE_TEMPLATE/feature.md`
+  - Meta / Process / Docs: `.github/ISSUE_TEMPLATE/meta.md`
+- Assign the appropriate milestone (e.g., "Executor & Worker (EW) — Native Async, Pump, Messaging").
+- Apply labels for ownership (`touches:*`), risk (`risk:*`), and type (`type:*`). Add `rollout:flagged` for gated features.
+
 ## Pull Request Guidelines
 
 - Provide a clear description of the changes

--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ capsule/
 
 ## Contributing
 
+We welcome contributions! Please read the guidelines and use our issue templates to keep work scoped and reviewable.
+
+- Contributing Guide: see `CONTRIBUTING.md` (development workflow, testing, PR guidance)
+- Issue Conventions (titles, labels, required sections, invariants, rollout/flags): `docs/PROCESS/ISSUE_CONVENTIONS.md`
+- GitHub Issue Templates: `.github/ISSUE_TEMPLATE/`
+
+
+## Contributing
+
 Capsule is in early development. Key areas needing contribution:
 
 - Phase 3: Native AsyncExecutor implementation

--- a/README.md
+++ b/README.md
@@ -1,60 +1,75 @@
 # Capsule
 
-> **Development Status**: 🚧 Experimental (v0.1.0-dev) - Phase 2c Complete, Phase 3 In Progress
+> Development Status: 🚧 Experimental (v0.1.0‑dev) — Phase 3 in progress
 
-A Python execution environment implementing subprocess isolation with persistent sessions and promise-based orchestration.
+Capsule is a Python Subprocess‑Isolated Execution Service (SIES). It provides persistent subprocess sessions, a framed async transport for streaming I/O, and durable request correlation to power interactive execution patterns.
 
-## Current State
+## Current Capabilities
 
-Capsule is an experimental **Subprocess-Isolated Execution Service (SIES)** in active development. The project has completed its foundation phases (0-2c) with working subprocess isolation, promise-based message correlation, and local-mode durability through Resonate SDK.
+### Protocol & Transport
+- Messages: Execute, Output, Input, InputResponse, Result, Error, Checkpoint, Restore, Ready, Heartbeat, Shutdown, Cancel, Interrupt.
+- Framed transport over stdin/stdout with MessagePack or JSON encoding.
+- Event‑driven FrameReader (asyncio.Condition). FrameBuffer still uses a small polling loop and is planned to move to Condition.
 
-### ✅ What's Working
-- **Subprocess isolation** with persistent namespace across executions
-- **ThreadedExecutor** for synchronous and blocking I/O code
-- **Promise-based message correlation** via ResonateProtocolBridge
-- **Input capability** for interactive code execution
-- **Local-mode checkpoint/restore** for session state
-- **Session pooling** for subprocess reuse
-- **Single-loop invariant** with message interceptors
+### Session
+- Lifecycle: start, shutdown, terminate, restart; `is_alive`; `Session.info()` updated via heartbeats.
+- Execution: `Session.execute(msg)` yields Output/Result/Error as an async generator; `input_response()` replies to Input; `cancel()`/`interrupt()` supported.
+- Routing: passive message interceptors (non‑blocking); single‑reader invariant (Session is the only transport reader); event‑driven receive loop with cancellable waits.
 
-### 🚧 In Development (Phase 3)
-- Native AsyncExecutor implementation (currently skeletal, delegates to ThreadedExecutor)
-- Full top-level await support via PyCF_ALLOW_TOP_LEVEL_AWAIT
-- Coroutine lifecycle management
-- Execution cancellation
+### Worker
+- Executes code via ThreadedExecutor today. Enforces strict output‑before‑result ordering by draining the event‑driven output pump.
+- If drain times out, emits an ErrorMessage and never a ResultMessage (preserves ordering).
+- Heartbeats (memory/CPU/namespace), Checkpoint/Restore (local mode), busy guard, cancel with grace timeout (escalates to restart if needed), and interrupt handling.
 
-### ❌ Not Yet Implemented
-- Full capability system (only Input capability exists)
-- Remote Resonate mode (distributed execution)
-- Performance optimizations beyond basic caching
-- Production monitoring and observability
-- Resource limits enforcement
-- Multi-language support
+### Executors
+- ThreadedExecutor (production path):
+  - Blocking‑safe via thread execution. Protocol `input()` shim (sends InputMessage, blocks for InputResponse).
+  - Event‑driven output pump (asyncio.Queue, flush sentinel), backpressure modes (block, drop_new, drop_oldest, error), cooperative cancellation via `sys.settrace`.
+  - Captures trailing expression value after exec blocks for REPL UX.
+  - Async wrapper `execute_code_async()` is test‑only — it suppresses drain timeout warnings; the worker remains strict.
+- AsyncExecutor (native paths implemented; worker routing pending):
+  - Compile‑first top‑level await using `PyCF_ALLOW_TOP_LEVEL_AWAIT`, then exec+flags; minimal AST wrapper fallback as last resort.
+  - Executes simple sync and async‑def defining code natively; optional flag‑gated transforms are default‑off.
+  - Bounded AST LRU and fallback linecache LRU; coroutine tracking and `cancel_current()` with counters and cleanup.
+  - Heuristics for BLOCKING_SYNC detection with overshadow/import guards reduce false positives. Used via DI/tests; worker routing is planned behind a flag.
 
-## Test Coverage
-- **Unit Tests**: 164/166 passing (98.8%)
-- **Integration Tests**: 36/40 passing (90%)
-- **Overall Coverage**: ~56%
+### Namespace
+- Merge‑only namespace policy; preserves `ENGINE_INTERNALS` (In/Out history, result slots `_`, `__`, `___`); never replaces the namespace dict.
+- Snapshots (create/restore/delete), serialization helpers, tracked function/class sources and imports.
 
-## Architecture
+### Session Pool
+- Event‑driven warmup (signals, no polling) with watermark checks.
+- Hybrid health check worker (timer baseline + event triggers).
+- Pool metrics and `get_info()` (hit rate, warmup/health metrics, acquisition latency, etc.).
 
-Current implementation follows a three-layer architecture:
+### Integration
+- ResonateProtocolBridge (local mode): durable promises for Execute/Input flows, structured timeout rejection, pending high‑water mark.
+- DI wiring for AsyncExecutor and a HITL Input capability. Lifecycle/metrics surfacing via `Session.info()` planned.
+
+## Design Invariants
+- Single‑reader transport: Session is the only transport reader.
+- Output‑before‑result: Worker drains output pump before Result; timeout → Error (no Result).
+- Merge‑only namespace: Never replace dict; preserve `ENGINE_INTERNALS` keys.
+- Pump‑only outputs: stdout/stderr routed through the async output pump.
+- Event‑driven I/O: Prefer Conditions/Events over polling (FrameBuffer refactor pending).
+
+## Architecture Overview
 
 ```
-Protocol Layer (Working)
-├── Message framing (4-byte prefix)
-├── MessagePack/JSON serialization
-└── Promise correlation
+Protocol Layer
+├── Framed transport (MessagePack/JSON)
+├── Event‑driven FrameReader (asyncio.Condition)
+└── Message schemas (messages.py)
 
-Execution Layer (Partial)
-├── ThreadedExecutor (working)
-├── AsyncExecutor (skeleton only)
-└── NamespaceManager (working)
+Execution Layer
+├── ThreadedExecutor (blocking‑safe, pump/backpressure, input shim)
+├── AsyncExecutor (TLA compile‑first; async‑def/simple sync native; AST fallback; caches; cancel_current)
+└── NamespaceManager (merge‑only; ENGINE_INTERNALS)
 
-Integration Layer (Local Only)
-├── ResonateProtocolBridge
-├── Session interceptors
-└── InputCapability
+Integration Layer (Local)
+├── ResonateProtocolBridge (durable promises)
+├── DI wiring (async executor, HITL capability)
+└── Session interceptors
 ```
 
 ## Installation
@@ -183,7 +198,7 @@ capsule/
 ├── src/
 │   ├── subprocess/       # Executors and namespace management
 │   │   ├── executor.py   # ThreadedExecutor (working)
-│   │   ├── async_executor.py # AsyncExecutor (skeleton)
+│   │   ├── async_executor.py # AsyncExecutor (native paths; worker routing pending)
 │   │   └── namespace.py  # Namespace management
 │   ├── session/          # Session and pool management
 │   ├── protocol/         # Message protocol and transport
@@ -196,27 +211,17 @@ capsule/
     └── development/     # Implementation notes
 ```
 
-## Architectural Decisions
+## Roadmap Highlights
 
-### Completed Decisions
-- **Namespace Merge-Only Policy**: Never replace namespace dict, always merge
-- **Single-Loop Invariant**: Session owns the sole event loop for transport
-- **Promise-First Integration**: Durable functions use ctx.promise pattern
-- **Capability-Based Security**: Security enforced at injection, not code analysis
+Workstreams (see milestones/issues):
+- Executor & Worker (EW): SessionConfig plumbing; AsyncExecutor lifecycle finalize; drain suppression knob; worker native async route (flagged); Display/Progress messages.
+- Protocol & Transport (PROTO): Event‑driven FrameBuffer; Hello/Ack negotiation; idempotency keys; durable streaming channels.
+- Bridge & Capabilities (BRIDGE): lifecycle + metrics via `Session.info()`; priority routing & interceptor quarantine; CapabilityRegistry & SecurityPolicy; input EOF/timeout semantics.
+- Session Pool (POOL): finalize warm imports and memory budgets; circuit breaker + metric safety.
+- Providers (PROV): SDK/contract tests; HTTP/Files/Shell providers with allowlists and caps.
+- Observability (OBS): distributed execution trace; safe introspection (redacted metadata).
 
-### Pending Decisions (Phase 3+)
-- Native async execution strategy (EventLoopCoordinator design)
-- Capability registry architecture
-- Remote mode connection management
-- Performance optimization priorities
-
-## Known Limitations
-
-1. **AsyncExecutor is skeletal** - All code currently executes via ThreadedExecutor
-2. **Local mode only** - No distributed execution yet
-3. **Limited capabilities** - Only Input capability implemented
-4. **No production features** - Missing metrics, monitoring, resource limits
-5. **Test coverage gaps** - Some integration tests still failing
+See `ROADMAP.md` for details.
 
 ## Contributing
 
@@ -231,7 +236,7 @@ We welcome contributions! Please read the guidelines and use our issue templates
 
 Capsule is in early development. Priority areas for contributions:
 
-- Phase 3: Native AsyncExecutor implementation
+- Phase 3: Worker native AsyncExecutor routing (flagged)
 - Capability system development
 - Test coverage improvement
 - Documentation

--- a/README.md
+++ b/README.md
@@ -227,12 +227,12 @@ We welcome contributions! Please read the guidelines and use our issue templates
 - GitHub Issue Templates: `.github/ISSUE_TEMPLATE/`
 
 
-## Contributing
+### Focus Areas
 
-Capsule is in early development. Key areas needing contribution:
+Capsule is in early development. Priority areas for contributions:
 
 - Phase 3: Native AsyncExecutor implementation
-- Phase 4: Capability system development
+- Capability system development
 - Test coverage improvement
 - Documentation
 - Performance optimization

--- a/docs/PROCESS/ISSUE_CONVENTIONS.md
+++ b/docs/PROCESS/ISSUE_CONVENTIONS.md
@@ -1,0 +1,183 @@
+# Issue Conventions
+
+This document standardizes how we write and manage issues across workstreams. The goal is fast triage, clear ownership, safe rollouts, and predictable outcomes.
+
+## Purpose
+- Make ownership, risks, sequencing, and acceptance criteria obvious.
+- Enable useful dashboards/search via consistent titles, labels, and sections.
+- Preserve core invariants (ordering, single-reader, namespace merge-only, etc.).
+
+## Scope
+- Applies to all issues across these milestones:
+  - Executor & Worker (EW) — Native Async, Pump, Messaging
+  - Session Pool (POOL) — Reliability, Warmup, Health
+  - Protocol & Transport (PROTO) — Negotiation, Framing, Idempotency, Streams
+  - Bridge & Capabilities (BRIDGE) — Lifecycle, Routing, Registry
+  - Providers (PROV) — HTTP, Files, Shell, SDK
+  - Observability (OBS) — Tracing & Introspection
+  - Meta (META) — Issue Quality & Templates
+
+## Milestone Naming
+- Milestone titles are human-readable with the short code in parentheses, e.g.
+  - "Executor & Worker (EW) — Native Async, Pump, Messaging"
+- Descriptions summarize themes, e.g. "AsyncExecutor lifecycle + worker native routing; output drain/pump policies; Display/Progress message UX."
+
+## Issue Titles
+- Format: `<WORKSTREAM>-NNN — Descriptive action`
+  - Example: `EW-010 — Worker: Route TLA/async-def to AsyncExecutor (delegate blocking sync)`
+- Avoid code-only titles — lists should be readable without expanding the issue.
+
+## Labels
+- Ownership `touches:*`:
+  - `touches:worker`, `touches:executor`, `touches:session`, `touches:pool`, `touches:protocol`, `touches:transport`, `touches:bridge`, `touches:capability-registry`, `touches:providers`, `touches:diagnostics`, `touches:integration`.
+- Risk `risk:*`:
+  - `risk:ordering`, `risk:single-reader`, `risk:compat`, `risk:perf`, `risk:security`.
+- Type `type:*`:
+  - `type:feature`, `type:refactor`, `type:hardening`, `type:docs`, `type:test`, `type:process`.
+- Rollout `rollout:*`:
+  - `rollout:flagged`, `rollout:alpha`.
+- Optional sequencing helpers:
+  - Use a "Depends on:" body section or helper labels like `depends-on:#` / `blocks:#` (body section preferred for clarity).
+
+## Required Issue Body Sections
+Use these sections (our templates include them):
+
+1) TL;DR
+- 1–3 lines describing the action and scope.
+
+2) Background / Problem
+- Why this matters; what is limited/incorrect today.
+
+3) Scope (In / Out)
+- Boundaries to avoid scope creep.
+
+4) Design Direction
+- High-level approach, key decisions, and any env knobs + defaults.
+
+5) Affected Paths
+- Canonical paths only, one per line (e.g., `src/protocol/messages.py`).
+
+6) Core Invariants
+- Workstream-relevant guardrails (see reference list below).
+
+7) Observability
+- Metrics/logs; warn-once policies; redaction policy where applicable.
+
+8) Test Plan
+- Unit/integration/e2e + filenames; prefer event-driven waits (no sleeps).
+
+9) Acceptance Criteria
+- Verifiable outcomes (behavior and validation), not just "merged".
+
+10) Dependencies & Rollout
+- `Depends on: #...` and any flags; add `rollout:flagged` label if gated.
+
+11) Risks & Mitigations
+- What could go wrong and how you’re preventing it.
+
+12) Docs
+- Specs/API/changelog to update.
+
+### Minimal issue body template (copyable)
+
+```
+TL;DR
+- <1–3 lines>
+
+Background / Problem
+- <context>
+
+Scope (In / Out)
+- In: <...>
+- Out: <...>
+
+Design Direction
+- <approach, env flags + defaults>
+
+Affected Paths
+- src/.../...
+- src/.../...
+
+Core Invariants
+- <invariants to preserve>
+
+Observability
+- <metrics/logs; warn-once; redaction>
+
+Test Plan
+- <unit/integration/e2e + filenames; event-driven waits>
+
+Acceptance Criteria
+- <verifiable outcomes>
+
+Dependencies & Rollout
+- Depends on: #...
+- Rollout: <flag name> (default OFF)
+
+Risks & Mitigations
+- <risks + mitigations>
+
+Docs
+- <specs/API/changelog to update>
+```
+
+## Workstream Core Invariants (reference)
+
+### Executor & Worker (EW)
+- Single-reader invariant (Session is the only transport reader).
+- Output-before-result ordering (worker drains outputs before ResultMessage; worker strict on drain timeout).
+- Merge-only namespace updates (preserve `ENGINE_INTERNALS` keys; no replacement of the namespace dict).
+- Pump-only stdout/stderr (no direct writes except narrowly-scoped emergency logs if unavoidable).
+- No event loop creation in durable layers (loops are owned by executor/transport).
+
+### Protocol & Transport (PROTO)
+- Framing integrity; bounded frame sizes.
+- Ack-before-result ordering (when Ack is present).
+- Idempotency correctness (keys, cache policy).
+- Event-driven (no polling) for readers/buffers.
+
+### Session Pool (POOL)
+- No await while holding locks.
+- Event-driven warmup (signals over polling).
+- Hybrid health check (timer baseline + event triggers).
+- Circuit breaker to avoid thundering herds.
+
+### Bridge & Capabilities (BRIDGE)
+- Single-reader invariant.
+- Deterministic correlation.
+- Passive interceptors; quarantine budgets and fairness (no data-path starvation).
+- Prompt shutdown rejection for pending correlations.
+
+### Providers (PROV)
+- Strict allowlists; size/time caps; structured observability.
+- Out-of-process execution (no in-process provider code execution).
+
+### Observability (OBS)
+- Bounded memory.
+- Metadata-only introspection; redaction policy.
+- No additional transport readers.
+
+## Rollout & Env Flags
+- Describe flags + defaults in Design Direction and Rollout sections.
+- Naming guidance:
+  - Worker: `WORKER_*` (e.g., `WORKER_ENABLE_NATIVE_ASYNC`).
+  - AsyncExecutor: `ASYNC_EXECUTOR_*` (e.g., `ASYNC_EXECUTOR_AST_CACHE_SIZE`).
+  - Protocol/Providers: `CAPS_*` acceptable, but prefer area-specific prefixes when wiring to code.
+- Precedence: constructor args > env.
+
+## Duplicates & Consolidation
+- Close duplicates with a short comment linking the canonical issue (e.g., "Closed as duplicate of #NN").
+- Prefer the newer, more complete issue as canonical.
+
+## Quality Checklist (on creation/edit)
+- [ ] Title follows pattern; milestone assigned.
+- [ ] Labels applied: touches, type, risk; rollout if flagged.
+- [ ] All required sections filled; Affected Paths canonical; Core Invariants listed.
+- [ ] Dependencies cross-linked; acceptance criteria testable.
+- [ ] Docs to update identified.
+
+## Examples (real patterns)
+- EW-010 — Worker routes async code to AsyncExecutor under a flag; preserves output-before-result and single-reader; depends on lifecycle/plumbing; worker remains strict on drain timeouts.
+- PROTO-010 — FrameBuffer switches to asyncio.Condition to eliminate polling; reduce idle CPU; maintain framing invariants.
+- BRIDGE-010 — Bridge lifecycle exposes metrics via Session.info(); close/cancel_all is idempotent; pending rejected on shutdown.
+


### PR DESCRIPTION
This PR improves our issue hygiene and developer UX.

Changes
- docs/PROCESS/ISSUE_CONVENTIONS.md: single canonical guide for issues and milestones
  - Milestone naming; issue title/labels; required sections; per‑workstream invariants
  - Rollout/flag guidance; duplicates policy; quality checklist; examples
- .github/ISSUE_TEMPLATE/: ready‑to‑use templates
  - feature.md for Feature/Refactor/Hardening
  - meta.md for Meta/Process/Docs
  - config.yml disables blank issues to encourage templates
- README/CONTRIBUTING: link to conventions and templates; add quick guidance
- AGENTS.md: point to conventions doc and templates; add short documentation practices note

Why
- Make ownership, risks, sequencing, and acceptance criteria obvious
- Keep dashboards/search useful via consistent labels and sections
- Prevent drift by linking to one canonical conventions doc

Follow‑ups
- Adopt templates on new issues
- Optional: align env flag prefixes in issue bodies to code (WORKER_*/ASYNC_EXECUTOR_*)
